### PR TITLE
Added shift operator to Transformation to apply it to a dataset.

### DIFF
--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -46,6 +46,7 @@ from gluonts.dataset.stat import (
     calculate_dataset_statistics,
 )
 
+
 # Dictionary used for data flowing through the transformations.
 # A Dataset is an iterable over such dictionaries.
 DataEntry = Dict[str, Any]

--- a/src/gluonts/transform/validation.py
+++ b/src/gluonts/transform/validation.py
@@ -1,0 +1,56 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import abc
+from typing import Any, Dict, List
+
+from gluonts.dataset.common import DataEntry
+from ._base import SimpleTransformation
+
+
+class Validation(SimpleTransformation):
+    """A Transformation that doesn't change the data, but just checks whether a
+    given entry is valid.
+    """
+
+    @abc.abstractmethod
+    def check(self, data: DataEntry) -> None:
+        pass
+
+    def transform(self, data: DataEntry) -> DataEntry:
+        self.check(data)
+        return data
+
+
+class ContainsField(Validation):
+    def __init__(self, *field_names: List[str]) -> None:
+        self.field_names = set(field_names)
+
+    def check(self, data: DataEntry) -> None:
+        missing = self.field_names - set(data)
+        if missing:
+            fields = ", ".join(sorted(missing))
+            raise ValueError(f"Entry is missing fields: {fields}.")
+
+
+class HasType(Validation):
+    def __init__(self, **types: Dict[Any, type]) -> None:
+        self.types = types
+
+    def check(self, data: DataEntry) -> None:
+        for field, expected_type in self.types.items():
+            if not isinstance(data[field], expected_type):
+                raise ValueError(
+                    f"Entry {field} was expected to be of instance "
+                    f"{expected_type}, but found type {type(data[field])}."
+                )


### PR DESCRIPTION
I think from the point of view of transformations, we be more generic and handle every stream of `DataEntry` (which is just a dict):

```python
# Dictionary used for data flowing through the transformations.
# A Dataset is an iterable over such dictionaries.
DataEntry = Dict[str, Any]
```

For example, `[{"foo": "bar"}]` is a valid dataset in the eyes of transformations.

---

Also, I like to use `{dataset} >> {transformation}` to apply a transformation to a dataset:

```python
dataset = [{}]
t = SetField("foo", 42) + SetField("bar", 99)
list(dataset >> t) == [{'foo': 42, 'bar': 99}]

# as a one liner
list([{}]>> SetField("foo", 42) + SetField("bar", 99)) == [{'foo': 42, 'bar': 99}]
```

---

Further, I propose to use `>` to apply a simple transformation:

```python
{} > SetField("foo" 42) == {'foo': 42}
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
