### PR TITLE
Make observed_value_field optional in TFTInstanceSplitter

### DIFF
--- a/requirements/requirements-extras-statsforecast.txt
+++ b/requirements/requirements-extras-statsforecast.txt
@@ -1,4 +1,4 @@
 # scipy cap can be removed once this is resolved: https://github.com/statsmodels/statsmodels/issues/9584
-scipy<=1.15.3; python_version > "3.7.0"
+scipy<1.16.0; python_version > "3.7.0"
 scipy~=1.7.3; python_version <= "3.7.0"
 statsforecast~=1.0

--- a/requirements/requirements-extras-statsforecast.txt
+++ b/requirements/requirements-extras-statsforecast.txt
@@ -1,1 +1,4 @@
+# scipy cap can be removed once this is resolved: https://github.com/statsmodels/statsmodels/issues/9584
+scipy<=1.15.3; python_version > "3.7.0"
+scipy~=1.7.3; python_version <= "3.7.0"
 statsforecast~=1.0

--- a/requirements/requirements-pytorch.txt
+++ b/requirements/requirements-pytorch.txt
@@ -3,5 +3,5 @@ lightning>=2.2.2,<2.5
 # Capping `lightning` does not cap `pytorch_lightning`, so we cap manually
 pytorch_lightning>=2.2.2,<2.5
 # scipy cap can be removed once this is resolved: https://github.com/statsmodels/statsmodels/issues/9584
-scipy<=1.15.3; python_version > "3.7.0"
+scipy<1.16.0; python_version > "3.7.0"
 scipy~=1.7.3; python_version <= "3.7.0"

--- a/requirements/requirements-pytorch.txt
+++ b/requirements/requirements-pytorch.txt
@@ -2,5 +2,6 @@ torch>=1.9,<3
 lightning>=2.2.2,<2.5
 # Capping `lightning` does not cap `pytorch_lightning`, so we cap manually
 pytorch_lightning>=2.2.2,<2.5
-scipy~=1.10; python_version > "3.7.0"
+# scipy cap can be removed once this is resolved: https://github.com/statsmodels/statsmodels/issues/9584
+scipy<=1.15.3; python_version > "3.7.0"
 scipy~=1.7.3; python_version <= "3.7.0"

--- a/src/gluonts/transform/split.py
+++ b/src/gluonts/transform/split.py
@@ -494,7 +494,7 @@ class TFTInstanceSplitter(InstanceSplitter):
         is_pad_field: str = FieldName.IS_PAD,
         start_field: str = FieldName.START,
         forecast_start_field: str = FieldName.FORECAST_START,
-        observed_value_field: str = FieldName.OBSERVED_VALUES,
+        observed_value_field: Optional[str] = FieldName.OBSERVED_VALUES,
         lead_time: int = 0,
         output_NTC: bool = True,
         time_series_fields: List[str] = [],
@@ -529,11 +529,9 @@ class TFTInstanceSplitter(InstanceSplitter):
 
         sampled_indices = self.instance_sampler(target)
 
-        slice_cols = (
-            self.ts_fields
-            + self.past_ts_fields
-            + [self.target_field, self.observed_value_field]
-        )
+        slice_cols = self.ts_fields + self.past_ts_fields + [self.target_field]
+        if self.observed_value_field is not None:
+            slice_cols.append(self.observed_value_field)
         for i in sampled_indices:
             pad_length = max(self.past_length - i, 0)
             d = data.copy()


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Previously, `TFTInstanceSplitter` assumed that the `observed_value_field` is always present in the entry. This PR fixes that. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup