### PR TITLE
Update numpy upper bound to `<2.5`

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.16,<2.2
+numpy>=1.16,<2.5
 pandas>=1.0,<3
 pydantic>=1.7,<3
 tqdm~=4.23


### PR DESCRIPTION
*Issue #, if available:* https://github.com/autogluon/autogluon/issues/5620

*Description of changes:* This PR relaxes the numpy upper bound to `<2.5` enabling more recent numpy releases. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup