### PR TITLE
Zebras: replace deprecated np.in1d with np.isin

### DIFF
--- a/src/gluonts/zebras/_period.py
+++ b/src/gluonts/zebras/_period.py
@@ -299,7 +299,7 @@ class Periods(_BasePeriod):
 
     def intersection(self, other):
         # TODO: Is this needed?
-        return self.data[np.in1d(self, other)]
+        return self.data[np.isin(self, other)]
 
     def index_of(self, period: Union[str, Period]):
         """


### PR DESCRIPTION
*Issue #, if available:* none (follow-up to #3227)

*Description of changes:*

The NumPy 2 compatibility cleanup in #3227 missed the single call site in `src/gluonts/zebras/_period.py:302`:

```python
def intersection(self, other):
    # TODO: Is this needed?
    return self.data[np.in1d(self, other)]
```

`np.in1d` was deprecated in NumPy 1.25 and removed in NumPy 2.2+, while `requirements/requirements.txt` currently allows `numpy>=1.16,<2.5`. On NumPy 2.2+ this raises `AttributeError`:

```
>>> import numpy as np; np.__version__
'2.4.4'
>>> np.in1d([1,2,3], [2])
AttributeError: module 'numpy' has no attribute 'in1d'. Did you mean: 'int16'?
```

The function signature of `np.isin` is a drop-in replacement (https://numpy.org/doc/stable/reference/generated/numpy.isin.html). This one-line swap is the same remedy #3227 applied elsewhere.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup