### PR TITLE
Datasets: use HTTPS for uber_tlc download URL

### DIFF
--- a/src/gluonts/dataset/repository/_uber_tlc.py
+++ b/src/gluonts/dataset/repository/_uber_tlc.py
@@ -39,7 +39,7 @@ def generate_uber_dataset(
         temp_dir_path = Path(dir_path)
         temp_zip_path = temp_dir_path / "uber-dataset.zip"
         uber_url_path = (
-            "http://raw.githubusercontent.com/fivethirtyeight/"
+            "https://raw.githubusercontent.com/fivethirtyeight/"
             "uber-tlc-foil-response/master/uber-trip-data/"
             "uber-raw-data-janjune-15.csv.zip"
         )


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:*

`src/gluonts/dataset/repository/_uber_tlc.py` still uses plaintext HTTP to fetch the Uber TLC dataset from `raw.githubusercontent.com`. GitHub has served Raw content over HTTPS for years, so the HTTP URL only exists as a 2019-era artifact. Keeping it as HTTP has two downsides:

1. On a compromised network an attacker can replace the downloaded `.zip` with an arbitrary payload. The same file is then passed to `zipfile.ZipFile.extractall` on line 48, so any hostile zip member name that contains `..` can land files outside `temp_dir_path`.
2. Some corporate/egress proxies refuse plain HTTP to GitHub entirely, making `get_dataset("uber_tlc_hourly")` fail on installs where every other dataset loader succeeds (those already use HTTPS).

This PR flips the single literal to `https://`. No other change is needed — GitHub Raw accepts the same path under HTTPS, and `urllib.request.urlretrieve` follows the scheme as given.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup