### PR TITLE
Datasets: finish pandas 2 freq alias migration in _tsf_reader

### DIFF
--- a/src/gluonts/dataset/repository/_tsf_reader.py
+++ b/src/gluonts/dataset/repository/_tsf_reader.py
@@ -48,7 +48,7 @@ def frequency_converter(freq: str):
 
 
 BASE_FREQ_TO_PANDAS_OFFSET: Dict[str, str] = {
-    "seconds": "S",
+    "seconds": "s",
     "minutely": "min",
     "minutes": "min",
     "hourly": "h",
@@ -57,12 +57,12 @@ BASE_FREQ_TO_PANDAS_OFFSET: Dict[str, str] = {
     "days": "D",
     "weekly": "W",
     "weeks": "W",
-    "monthly": "M",
-    "months": "M",
-    "quarterly": "Q",
-    "quarters": "Q",
-    "yearly": "Y",
-    "years": "Y",
+    "monthly": "ME",
+    "months": "ME",
+    "quarterly": "QE",
+    "quarters": "QE",
+    "yearly": "YE",
+    "years": "YE",
 }
 
 

--- a/test/dataset/test_tsf_reader.py
+++ b/test/dataset/test_tsf_reader.py
@@ -19,7 +19,7 @@ from gluonts.dataset.repository._tsf_reader import frequency_converter
 @pytest.mark.parametrize(
     "input_freq_str, output_freq_str",
     [
-        ("30_seconds", "30S"),
+        ("30_seconds", "30s"),
         ("minutely", "min"),
         ("10_minutes", "10min"),
         ("hourly", "h"),
@@ -28,12 +28,12 @@ from gluonts.dataset.repository._tsf_reader import frequency_converter
         ("7_days", "7D"),
         ("weekly", "W"),
         ("4_weeks", "4W"),
-        ("monthly", "M"),
-        ("2_months", "2M"),
-        ("quarterly", "Q"),
-        ("2_quarters", "2Q"),
-        ("yearly", "Y"),
-        ("2_years", "2Y"),
+        ("monthly", "ME"),
+        ("2_months", "2ME"),
+        ("quarterly", "QE"),
+        ("2_quarters", "2QE"),
+        ("yearly", "YE"),
+        ("2_years", "2YE"),
     ],
 )
 def test_frequency_converter(input_freq_str: str, output_freq_str: str):


### PR DESCRIPTION
*Issue #, if available:* follow-up to #3232

*Description of changes:*

#3232 replaced a few of the pandas offset aliases that became deprecated in pandas 2.2 (e.g. `H → h`, `T → min`), but `_tsf_reader.py` still emits the remaining deprecated ones: `S`, `M`, `Q`, `Y`. On pandas 2.3 they produce FutureWarnings, and they are scheduled to stop working in pandas 3.0.

```python
>>> import pandas as pd; pd.__version__
'2.3.3'
>>> from gluonts.dataset.repository._tsf_reader import BASE_FREQ_TO_PANDAS_OFFSET as M
>>> M["monthly"], M["quarterly"], M["yearly"], M["seconds"]
('M', 'Q', 'Y', 'S')
>>> pd.tseries.frequencies.to_offset("30S")
FutureWarning: 'S' is deprecated and will be removed in a future version, please use 's' instead.
>>> pd.tseries.frequencies.to_offset("1M")
FutureWarning: 'M' is deprecated and will be removed in a future version, please use 'ME' instead.
```

The mapping is the single source used by `frequency_converter`, which is called by `datasets.get_dataset` → `_tsf_datasets.py` when loading any dataset derived from `forecastingdata.org` (`tourism_monthly`, `tourism_quarterly`, `tourism_yearly`, `cif_2016`, `m5`, etc.).

Changes:

- `src/gluonts/dataset/repository/_tsf_reader.py`: migrate the four remaining aliases to the pandas-2-compatible spellings (`s`, `ME`, `QE`, `YE`).
- `test/dataset/test_tsf_reader.py`: update the expected values in `test_frequency_converter` accordingly, pinning the new contract.

```
test/dataset/test_tsf_reader.py ...............                          [100%]
============================== 15 passed in 0.13s ==============================
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup