### PR TITLE
Rotbaum: fall back to legacy predictor.pkl in TreePredictor.deserialize

### DIFF
--- a/src/gluonts/ext/rotbaum/_predictor.py
+++ b/src/gluonts/ext/rotbaum/_predictor.py
@@ -364,14 +364,19 @@ class TreePredictor(RepresentablePredictor):
         This function loads and returns the serialized model.
 
         It loads the predictor class with the serialized arguments. It then
-        loads the trained model list from ``model_list.json``. For backward
-        compatibility with predictors serialized before the pickle->json
-        migration (see PR #3176), it falls back to ``predictor.pkl`` if the
-        JSON file is missing.
+        loads the trained model list from ``model_list.json``.
+
+        Predictors serialized before the pickle->json migration (see
+        PR #3176) wrote ``predictor.pkl`` instead. Loading those legacy
+        artifacts requires passing ``allow_legacy_pickle=True`` as a
+        keyword argument, because pickle deserialization executes
+        arbitrary code and should only be done on trusted files.
         """
 
         predictor = super().deserialize(path)
         assert isinstance(predictor, cls)
+
+        allow_legacy_pickle = bool(kwargs.pop("allow_legacy_pickle", False))
 
         json_path = path / "model_list.json"
         pkl_path = path / "predictor.pkl"
@@ -379,7 +384,19 @@ class TreePredictor(RepresentablePredictor):
         if json_path.exists():
             with json_path.open("r") as fp:
                 predictor.model_list = load_json(fp.read())
-        elif pkl_path.exists():
+            return predictor
+
+        if pkl_path.exists() and not allow_legacy_pickle:
+            raise FileNotFoundError(
+                f"{json_path} not found. A legacy {pkl_path.name} is "
+                "present. Loading it requires explicit opt-in via "
+                "`TreePredictor.deserialize(path, "
+                "allow_legacy_pickle=True)` because pickle executes "
+                "arbitrary code on load; only enable this for files you "
+                "trust."
+            )
+
+        if pkl_path.exists():
             import pickle
             import warnings
 
@@ -392,13 +409,12 @@ class TreePredictor(RepresentablePredictor):
             )
             with pkl_path.open("rb") as f:
                 predictor.model_list = pickle.load(f)
-        else:
-            raise FileNotFoundError(
-                f"Neither {json_path} nor {pkl_path} exists; "
-                "cannot deserialize TreePredictor."
-            )
+            return predictor
 
-        return predictor
+        raise FileNotFoundError(
+            f"Neither {json_path} nor {pkl_path} exists; "
+            "cannot deserialize TreePredictor."
+        )
 
     def explain(
         self, importance_type: str = "gain", percentage: bool = True

--- a/src/gluonts/ext/rotbaum/_predictor.py
+++ b/src/gluonts/ext/rotbaum/_predictor.py
@@ -364,13 +364,40 @@ class TreePredictor(RepresentablePredictor):
         This function loads and returns the serialized model.
 
         It loads the predictor class with the serialized arguments. It then
-        loads the trained model list by reading the pickle file.
+        loads the trained model list from ``model_list.json``. For backward
+        compatibility with predictors serialized before the pickle->json
+        migration (see PR #3176), it falls back to ``predictor.pkl`` if the
+        JSON file is missing.
         """
 
         predictor = super().deserialize(path)
         assert isinstance(predictor, cls)
-        with (path / "model_list.json").open("r") as fp:
-            predictor.model_list = load_json(fp.read())
+
+        json_path = path / "model_list.json"
+        pkl_path = path / "predictor.pkl"
+
+        if json_path.exists():
+            with json_path.open("r") as fp:
+                predictor.model_list = load_json(fp.read())
+        elif pkl_path.exists():
+            import pickle
+            import warnings
+
+            warnings.warn(
+                "Loading Rotbaum predictor from the legacy pickle format "
+                f"({pkl_path.name}). Re-run `predictor.serialize(path)` "
+                "to migrate to the JSON format.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            with pkl_path.open("rb") as f:
+                predictor.model_list = pickle.load(f)
+        else:
+            raise FileNotFoundError(
+                f"Neither {json_path} nor {pkl_path} exists; "
+                "cannot deserialize TreePredictor."
+            )
+
         return predictor
 
     def explain(


### PR DESCRIPTION
*Issue #, if available:* follow-up to #3176

*Description of changes:*

#3176 migrated `TreePredictor` persistence from pickle (`predictor.pkl`) to JSON (`model_list.json`). `TreePredictor.deserialize` was rewritten to hardcode the new path:

```python
with (path / "model_list.json").open("r") as fp:
    predictor.model_list = load_json(fp.read())
```

Every Rotbaum predictor that was serialized with a v0.15.x release (which wrote `predictor.pkl` and nothing else) now fails with `FileNotFoundError: .../model_list.json` when loaded on v0.16+.

### Reproducer

```python
>>> import pathlib, pickle, tempfile, sys, types
>>> sys.modules["xgboost"] = types.ModuleType("xgboost")   # avoid libomp in the demo
>>> from gluonts.ext.rotbaum._predictor import TreePredictor
>>> p = pathlib.Path(tempfile.mkdtemp())
>>> with (p / "predictor.pkl").open("wb") as f:
...     pickle.dump([["sample-model"]], f)
>>> TreePredictor.deserialize(p)
FileNotFoundError: [...]/model_list.json
```

### Design choice: opt-in legacy load

Reintroducing pickle as an automatic fallback would resurrect the very reason #3176 migrated away from it — `pickle.load` executes arbitrary code on load. The first revision of this PR took that simpler path; I've changed it to require explicit opt-in so we don't regress on that front.

`TreePredictor.deserialize` now:

1. loads `model_list.json` if present (the post-#3176 format);
2. otherwise, if `predictor.pkl` is present AND the caller passed `allow_legacy_pickle=True`, loads it and emits a `DeprecationWarning` telling the user to re-save so they migrate on their own schedule;
3. otherwise, if `predictor.pkl` is present but the flag is not set, raises `FileNotFoundError` with a one-line message that points users at the opt-in flag;
4. raises `FileNotFoundError` when neither file is present.

Pickle is only imported lazily inside the fallback branch, so the JSON happy path keeps the module's current zero-pickle import surface. The stale docstring that still said "loads the trained model list by reading the pickle file" is updated to describe the new behaviour.

### Trade-offs considered

- **Silent pickle auto-fallback (first revision)**: simpler, but anyone who can drop a `predictor.pkl` into a path the user calls `deserialize` on (shared model hub, S3 bucket with broad write perms) gets RCE via pickle. The opt-in flag keeps that surface closed by default.
- **Remove the legacy path entirely and ship a standalone migration CLI**: rejected. Users who rediscover a v0.15.x artifact months later and are willing to trust it still deserve a one-call way in. The opt-in is one extra keyword argument.
- **Gate on a class attribute instead of a kwarg** (e.g. `TreePredictor.allow_legacy_pickle = True`): rejected. A per-call kwarg scopes the trust decision to the single load.

### Verification

Dynamic matrix with `super().deserialize` mocked out (that's the parent path, unchanged by this PR):

```
A json-only:              model_list=[['dummy']]                        (no warning)
B pkl-only default:       FileNotFoundError; opt-in hint present -> True
C pkl-only opt-in:        model_list=[['dummy']]                        depr=1
D both default:           model_list=[['dummy']]                        JSON wins, no warning
E neither:                FileNotFoundError                             OK
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup