### PR TITLE
test: pin TFTInstanceSplitter observed_value_field=None branch (#3296 item 3)

### DIFF
--- a/test/transform/test_transform.py
+++ b/test/transform/test_transform.py
@@ -1200,3 +1200,61 @@ def test_valmap():
 
     for entry in Valmap(str)(data, is_train=False):
         assert entry == {"a": "1", "b": "[2]"}
+
+
+@pytest.mark.parametrize("observed_value_field", [None, FieldName.OBSERVED_VALUES])
+def test_TFTInstanceSplitter_observed_value_field_optional(observed_value_field):
+    """
+    Regression test for #3259 (umbrella #3296 item 3).
+
+    PR #3259 made ``observed_value_field`` optional in
+    ``TFTInstanceSplitter``. Before the change, the splitter required a
+    string and would slice a corresponding array out of every entry.
+    After the change, callers can pass ``None`` to opt out — useful for
+    pipelines that don't precompute an observed-value mask. This test
+    pins both branches:
+
+    - ``observed_value_field=None``: the splitter must not look up an
+      observed-value array on the entry, and the output must contain
+      neither ``past_<observed>`` nor ``<observed>`` keys.
+    - ``observed_value_field=FieldName.OBSERVED_VALUES`` (default-like):
+      the splitter slices the array and emits ``past_<observed>``.
+    """
+    from gluonts.transform.split import TFTInstanceSplitter
+
+    past_length = 10
+    future_length = 5
+    target = np.arange(50, dtype=float)
+
+    data = {
+        FieldName.START: pd.Period("2021-01-01", freq="D"),
+        FieldName.TARGET: target,
+    }
+    # Only precompute the observed-values mask when the splitter is
+    # configured to use it; the None branch must not require it.
+    if observed_value_field is not None:
+        data[FieldName.OBSERVED_VALUES] = np.ones_like(target)
+
+    splitter = TFTInstanceSplitter(
+        instance_sampler=transform.TestSplitSampler(),
+        past_length=past_length,
+        future_length=future_length,
+        observed_value_field=observed_value_field,
+    )
+
+    out = list(splitter.flatmap_transform(data, is_train=False))
+    assert len(out) == 1
+    entry = out[0]
+
+    # Past-target slice is always present and has the configured length.
+    assert entry["past_target"].shape[-1] == past_length
+
+    past_observed_key = f"past_{FieldName.OBSERVED_VALUES}"
+    if observed_value_field is None:
+        # No observed-value array was looked up or emitted.
+        assert past_observed_key not in entry
+        assert FieldName.OBSERVED_VALUES not in entry
+    else:
+        # The default-like branch slices the mask and emits past_observed_values.
+        assert past_observed_key in entry
+        assert entry[past_observed_key].shape[-1] == past_length


### PR DESCRIPTION
*Issue #, if available:* refs #3296 (item 3)

*Description of changes:*

## Summary

Add a regression test pinning the `observed_value_field=None` branch of `TFTInstanceSplitter`, introduced by #3259 but not covered by the test suite.

## Context

#3296 enumerates regression-test gaps left by recent merged PRs. Item 3:

> **#3259 — `observed_value_field: Optional[str]`**: no test passing `None` through `TFTInstanceSplitter` on a toy dataset. The happy path with the default field name is covered; the new `None` branch isn't.

`grep -rn TFTInstanceSplitter test/` confirms there were zero direct tests for this class. Without a test, a future refactor could regress the `None` branch silently — the `flatmap_transform` method only branches on `if self.observed_value_field is not None:` (`src/gluonts/transform/split.py:533-534`), and the integration tests in `test/torch/model/test_estimators.py` only exercise the default field-name path.

## Changes

- `test/transform/test_transform.py`: add `test_TFTInstanceSplitter_observed_value_field_optional`, a `pytest.parametrize` over `[None, FieldName.OBSERVED_VALUES]` that:
  - Runs the splitter end-to-end on a small `data` dict using `TestSplitSampler`.
  - Asserts `past_target` always has the configured `past_length`.
  - Asserts the `None` branch emits **neither** `observed_values` **nor** `past_observed_values`, and does not require the entry to carry an observed-values array.
  - Asserts the default-like branch emits `past_observed_values` with the right length.

A short docstring on the test cites #3259 and #3296 so a reviewer reading the test cold sees the regression it guards.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
git clone https://github.com/awslabs/gluonts.git /tmp/repro && cd /tmp/repro
python3.11 -m venv .venv && source .venv/bin/activate
pip install -e . pytest

# --- BEFORE (origin/dev) ---
git checkout origin/dev
pytest test/transform/test_transform.py -q -k TFTInstanceSplitter
# Expected: 0 tests collected — there is no TFTInstanceSplitter test on dev.

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/gluonts.git feat/3296a-tft-splitter-test
git checkout FETCH_HEAD
pytest test/transform/test_transform.py -q -k TFTInstanceSplitter
# Expected: 2 passed — both branches pinned.
```

## What I ran locally

- `pytest test/transform/test_transform.py -q` → **252 passed, 4 skipped** on the branch (was 250 + 4 on dev; +2 from this PR).
- `pytest test/transform/test_transform.py -q -k TFTInstanceSplitter` → **2 passed**.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | `observed_value_field=None` | data dict without an observed-values array | splitter returns one entry; no `observed_values` / `past_observed_values` keys | `test_TFTInstanceSplitter_observed_value_field_optional[None]` |
| 2 | `observed_value_field=FieldName.OBSERVED_VALUES` | data dict with `observed_values` mask | splitter returns one entry with `past_observed_values` of length `past_length` | `test_TFTInstanceSplitter_observed_value_field_optional[observed_values]` |

## Risk / blast radius

Test-only addition. Zero runtime impact.

## Release note

```release-note
NONE
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup

---

*PR drafted with assistance from Claude Code. The reproducer block above was used during development and is the same one a reviewer can paste verbatim.*
