### PR TITLE
test: pin PatchTSTModel time-features shape with num_feat_dynamic_real>0 (#3296 item 6)

### DIFF
--- a/test/torch/model/test_modules.py
+++ b/test/torch/model/test_modules.py
@@ -96,3 +96,74 @@ def test_module_smoke(module, batch_size, expected_shapes, expected_dtypes):
     batch = module.describe_inputs(batch_size).zeros()
     outputs = module(**batch)
     assert_shapes_and_dtypes(outputs, expected_shapes, expected_dtypes)
+
+
+@pytest.mark.parametrize("num_feat_dynamic_real", [1, 3])
+def test_PatchTSTModel_time_features_shape(num_feat_dynamic_real):
+    """
+    Regression test for #3167 (umbrella #3296 item 6).
+
+    PR #3167 added ``num_feat_dynamic_real`` support to PatchTST,
+    routing extra real-valued time features through ``past_time_feat``
+    / ``future_time_feat`` of shape
+    ``(batch, length, num_feat_dynamic_real)``. The existing
+    ``test_module_smoke`` only exercises modules at the default
+    ``num_feat_dynamic_real=0``, so the time-feature branch is not
+    pinned anywhere in the test suite.
+
+    This test pins both the ``describe_inputs()`` shape contract (so a
+    future refactor of the ``Input`` spec doesn't silently change the
+    layout) and a forward-pass shape sanity check that the new fields
+    actually flow through the encoder.
+    """
+    from gluonts.torch.model.patch_tst import PatchTSTModel
+
+    batch_size = 2
+    context_length = 24
+    prediction_length = 12
+
+    module = PatchTSTModel(
+        prediction_length=prediction_length,
+        context_length=context_length,
+        patch_len=16,
+        stride=8,
+        padding_patch="end",
+        d_model=8,
+        nhead=2,
+        dim_feedforward=16,
+        dropout=0.0,
+        activation="relu",
+        norm_first=False,
+        num_encoder_layers=1,
+        scaling="mean",
+        num_feat_dynamic_real=num_feat_dynamic_real,
+    )
+
+    spec = module.describe_inputs(batch_size)
+
+    # Shape contract: time-feature inputs are present and have the
+    # expected layout. Order matters for downstream code that flattens
+    # the spec into positional kwargs.
+    assert "past_time_feat" in spec
+    assert "future_time_feat" in spec
+    assert spec.shapes["past_time_feat"] == (
+        batch_size,
+        context_length,
+        num_feat_dynamic_real,
+    )
+    assert spec.shapes["future_time_feat"] == (
+        batch_size,
+        prediction_length,
+        num_feat_dynamic_real,
+    )
+
+    # Forward-pass sanity: feeding the spec'd zeros must produce
+    # distribution args matching prediction_length, with no shape
+    # mismatch when concatenating time-feature patches into the encoder
+    # input. distr_args is a tuple of tensors (per StudentTOutput).
+    batch = module.describe_inputs(batch_size).zeros()
+    distr_args, loc, scale = module(**batch)
+    assert loc.shape == (batch_size, 1)
+    assert scale.shape == (batch_size, 1)
+    for arg in distr_args:
+        assert arg.shape[:2] == (batch_size, prediction_length)


### PR DESCRIPTION
*Issue #, if available:* refs #3296 (item 6)

*Description of changes:*

## Summary

Add a regression test pinning `PatchTSTModel`'s time-features branch (`num_feat_dynamic_real > 0`), introduced by #3167 but not exercised by the existing module-level test suite.

## Context

#3296 enumerates regression-test gaps left by recent merged PRs. Item 6:

> **#3167 — PatchTST time features**: no test asserting shape/ordering of `past_time_feat`/`future_time_feat` when `num_feat_dynamic_real > 0`. Current tests keep it at the default `0`.

Concretely, `test/torch/model/test_modules.py::test_module_smoke` covers DeepAR, MQF2, SimpleFeedForward, and TFT, but PatchTST is absent and the only PatchTST tests in the suite (`test/torch/model/test_estimators.py`) construct estimators without setting `num_feat_dynamic_real`, so the `if self.num_feat_dynamic_real > 0` branch in `PatchTSTModel.describe_inputs` and `PatchTSTModel.forward` (`src/gluonts/torch/model/patch_tst/module.py:173, 228`) is never exercised by pytest.

## Changes

- `test/torch/model/test_modules.py`: add `test_PatchTSTModel_time_features_shape`, parametrized over `num_feat_dynamic_real ∈ {1, 3}`, that:
  - Constructs `PatchTSTModel` with explicit time-feature support (small `d_model=8`, `nhead=2`, `num_encoder_layers=1` to keep the test fast).
  - Asserts `describe_inputs()` emits `past_time_feat` of shape `(batch, context_length, num_feat_dynamic_real)` and `future_time_feat` of shape `(batch, prediction_length, num_feat_dynamic_real)`.
  - Runs a forward pass on the spec'd zeros and asserts `distr_args` / `loc` / `scale` shapes are sane (this catches a regression in either the `take_last`+`unfold` patching of time features or the `cat([inputs, time_feat_patches], dim=-1)` projection alignment).

A short docstring on the test cites #3167 and #3296 so a reviewer reading the test cold sees what regression it guards.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
git clone https://github.com/awslabs/gluonts.git /tmp/repro && cd /tmp/repro
python3.11 -m venv .venv && source .venv/bin/activate
pip install -e . pytest torch lightning scipy cpflows

# --- BEFORE (origin/dev) ---
git checkout origin/dev
pytest test/torch/model/test_modules.py -q -k PatchTST
# Expected: 0 tests collected — PatchTST is not in test_modules.py.

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/gluonts.git feat/3296b-patch-tst-time-feat-test
git checkout FETCH_HEAD
pytest test/torch/model/test_modules.py -q -k PatchTST
# Expected: 2 passed — both num_feat_dynamic_real values pinned.
```

## What I ran locally

- `pytest test/torch/model/test_modules.py -q` → **6 passed in 14s** on the branch (was 4 on dev; +2 from this PR).
- `pytest test/torch/model/test_modules.py -q -k PatchTST` → **2 passed**.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Single dynamic feature | `num_feat_dynamic_real=1` | `past_time_feat.shape = (batch, context_length, 1)`, `future_time_feat.shape = (batch, prediction_length, 1)`, forward returns sane shapes | `test_PatchTSTModel_time_features_shape[1]` |
| 2 | Multiple dynamic features | `num_feat_dynamic_real=3` | last dim of both time-feat inputs is 3; forward pass succeeds | `test_PatchTSTModel_time_features_shape[3]` |

## Risk / blast radius

Test-only addition. No runtime change.

## Release note

```release-note
NONE
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup

---

*PR drafted with assistance from Claude Code. The reproducer block above was used during development and is the same one a reviewer can paste verbatim.*
