### PR TITLE
deps: widen toolz upper bound to <2 (allow toolz 1.x)

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.16,<2.5
 pandas>=1.0,<3
 pydantic>=1.7,<3
 tqdm~=4.23
-toolz~=0.10
+toolz>=0.10,<2
 
 # used for Protocol, can be removed once Python 3.8 is required
 typing-extensions~=4.0


### PR DESCRIPTION
*Issue #, if available:* #3271

*Description of changes:*

## Summary

Widen the `toolz` upper bound from `~=0.10` (i.e. `<0.11`) to `>=0.10,<2` so users can install gluonts alongside `toolz>=1.0`.

## Context

`toolz` 1.0 was released October 2024. The 1.x release is documented as backward-compatible with 0.12: there were no API removals, no signature changes, just packaging-side changes. Reported in #3271 as a blocker for downstream environments that have already moved to `toolz>=1.0`.

## Changes

- `requirements/requirements.txt`: replace `toolz~=0.10` with `toolz>=0.10,<2`. Keeping the lower bound at 0.10 preserves compatibility for existing deployments; the new upper bound of `<2` gives a safety margin against a hypothetical (currently un-announced) 2.0 with API breakage.

I audited every `toolz` / `toolz.dicttoolz` / `toolz.itertoolz` import in the tree to confirm 1.x compatibility:

```
src/gluonts/zebras/_split_frame.py    : first, keymap, valmap, dissoc, merge
src/gluonts/zebras/_repr.py           : curry
src/gluonts/zebras/_time_series.py    : first
src/gluonts/zebras/_time_frame.py     : first, valmap, dissoc, merge, itemmap, take
src/gluonts/zebras/_util.py           : valmap
src/gluonts/itertools.py              : curry
src/gluonts/transform/convert.py      : valmap
src/gluonts/ext/prophet/_predictor.py : import toolz
src/gluonts/model/evaluation.py       : first, valmap
src/gluonts/ext/rotbaum/_predictor.py : first
src/gluonts/core/serde/flat.py        : keymap, valmap (from toolz.dicttoolz)
src/gluonts/model/inputs.py           : valmap
src/gluonts/core/serde/_base.py       : valmap (from toolz.dicttoolz)
src/gluonts/shell/env.py              : valmap
src/gluonts/shell/sagemaker/...       : valmap, keyfilter
src/gluonts/nursery/glide/parallel.py : partition_all (from toolz.itertoolz)
```

All of these names, paths, and signatures are unchanged in toolz 1.x.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
git clone https://github.com/awslabs/gluonts.git /tmp/repro && cd /tmp/repro
python3.11 -m venv .venv && source .venv/bin/activate

# --- BEFORE (origin/dev) ---
git checkout origin/dev
pip install -e . "toolz==1.1.0"
# Expected: pip's resolver flags 'toolz~=0.10' vs installed 1.1.0 as a dependency conflict.
pip check 2>&1 | grep -i toolz
# Expected output line:
# "gluonts ... has requirement toolz~=0.10, but you have toolz 1.1.0."

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/gluonts.git feat/3271-toolz-1-0
git checkout FETCH_HEAD
pip install -e . "toolz==1.1.0"
pip check
# Expected: no toolz-related warning; pip check is clean.
pytest test/dataset test/test_itertools.py test/transform test/core test/test_util.py test/zebras -q
# Expected: 493 passed, 6 skipped, 1 xfailed.
```

## What I ran locally

- `pip install -q "toolz==1.1.0"` → installed cleanly.
- `pytest test/dataset test/test_itertools.py test/transform test/core test/test_util.py test/zebras -q` → **493 passed, 6 skipped, 1 xfailed in 2.83s**.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | toolz 0.12 (existing floor) | environment with `toolz==0.12.x` | gluonts imports and tests still pass | resolver allows it (lower bound preserved) |
| 2 | toolz 1.0 | environment with `toolz==1.0.0` | imports + 493 tests pass | manual `pip install toolz==1.0.0` and pytest run |
| 3 | toolz 1.1 | environment with `toolz==1.1.0` | same as above | the local run cited above |

## Risk / blast radius

Tiny. This is a requirements-file-only change. The lower bound is preserved (`>=0.10`), so no environment that currently resolves on dev will fail to resolve after this PR. The code itself is untouched.

## Release note

```release-note
Widen `toolz` dependency to allow toolz 1.x.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup

---

*PR drafted with assistance from Claude Code. The reproducer block above was used during development and is the same one a reviewer can paste verbatim.*
