### PR TITLE
Replace deprecated np.in1d with np.isin in zebras

### DIFF
--- a/src/gluonts/zebras/_period.py
+++ b/src/gluonts/zebras/_period.py
@@ -305,7 +305,7 @@ class Periods(_BasePeriod):
 
     def intersection(self, other):
         # TODO: Is this needed?
-        return self.data[np.in1d(self, other)]
+        return self.data[np.isin(self, other)]
 
     def index_of(self, period: Union[str, Period]):
         """

--- a/test/zebras/test_period.py
+++ b/test/zebras/test_period.py
@@ -157,3 +157,14 @@ def test_weekly_weekday_period(date, freq, result):
         zb.period(date, freq).periods(4).data,
         np.array(result).astype(np.datetime64),
     )
+
+
+def test_periods_intersection():
+    """Periods.intersection should work on NumPy 2.2+ (no np.in1d)."""
+    ps1 = zb.periods("2020-01", "D", 10)
+    ps2 = zb.periods("2020-01-03", "D", 5)
+
+    intersected = ps1.intersection(ps2)
+    assert len(intersected) == 5
+    # intersection returns a numpy array of datetime64 values
+    assert intersected.dtype == np.dtype("datetime64[D]")


### PR DESCRIPTION
## What changed

One-line swap: \`np.in1d\` → \`np.isin\` in \`src/gluonts/zebras/_period.py\`.

\`np.in1d\` was deprecated in NumPy 1.25 and removed in NumPy 2.2+. On NumPy 2.2+ this raises:

\`\`\`
AttributeError: module 'numpy' has no attribute 'in1d'. Did you mean: 'int16'?
\`\`\`

\`np.isin\` is a drop-in replacement with identical semantics.

## Backward compat

No change in behavior. \`np.isin\` has been available since NumPy 1.13, well below the current minimum (\`>=1.16\`).

Fixes #3289