### PR TITLE
Enfore weights_only=True on estimator load

### DIFF
--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -228,7 +228,7 @@ class PyTorchLightningEstimator(Estimator):
                 f"Loading best model from {checkpoint.best_model_path}"
             )
             best_model = training_network.__class__.load_from_checkpoint(
-                checkpoint.best_model_path
+                checkpoint.best_model_path, weights_only=True
             )
         else:
             best_model = training_network


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Enforce `weights_only=True` on estimator load

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup