### PR TITLE
Bump lightning to <2.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,8 +97,8 @@ test = [
 
 torch = [
     "torch>=1.13,<3",
-    "lightning>=2.2.2,<2.6",
-    "pytorch_lightning>=2.2.2,<2.6",
+    "lightning>=2.2.2,<2.7",
+    "pytorch_lightning>=2.2.2,<2.7",
     "scipy",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ test = [
 ]
 
 torch = [
-    "torch>=1.13,<3",
+    "torch>=2.10,<3",
     "lightning>=2.2.2,<2.7",
     "pytorch_lightning>=2.2.2,<2.7",
     "scipy",

--- a/src/gluonts/torch/model/d_linear/lightning_module.py
+++ b/src/gluonts/torch/model/d_linear/lightning_module.py
@@ -48,7 +48,6 @@ class DLinearLightningModule(pl.LightningModule):
         weight_decay: float = 1e-8,
     ):
         super().__init__()
-        self.save_hyperparameters()
         self.model = DLinearModel(**model_kwargs)
         self.lr = lr
         self.weight_decay = weight_decay

--- a/src/gluonts/torch/model/deepar/lightning_module.py
+++ b/src/gluonts/torch/model/deepar/lightning_module.py
@@ -53,7 +53,6 @@ class DeepARLightningModule(pl.LightningModule):
         patience: int = 10,
     ) -> None:
         super().__init__()
-        self.save_hyperparameters()
         self.model = DeepARModel(**model_kwargs)
         self.lr = lr
         self.weight_decay = weight_decay

--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -228,7 +228,7 @@ class PyTorchLightningEstimator(Estimator):
                 f"Loading best model from {checkpoint.best_model_path}"
             )
             best_model = training_network.__class__.load_from_checkpoint(
-                checkpoint.best_model_path
+                checkpoint.best_model_path, weights_only=True
             )
         else:
             best_model = training_network

--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -228,7 +228,7 @@ class PyTorchLightningEstimator(Estimator):
                 f"Loading best model from {checkpoint.best_model_path}"
             )
             best_model = training_network.__class__.load_from_checkpoint(
-                checkpoint.best_model_path, weights_only=True
+                checkpoint.best_model_path,
             )
         else:
             best_model = training_network

--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -233,6 +233,7 @@ class PyTorchLightningEstimator(Estimator):
             best_model = training_network
             best_checkpoint = torch.load(
                 checkpoint.best_model_path,
+                # load to CPU to avoid a redundant copy on the model's device
                 map_location="cpu",
                 weights_only=True,
             )

--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -16,6 +16,7 @@ import logging
 
 import numpy as np
 import lightning.pytorch as pl
+import torch
 import torch.nn as nn
 
 from gluonts.core.component import validated
@@ -194,7 +195,7 @@ class PyTorchLightningEstimator(Estimator):
 
         monitor = "train_loss" if validation_data is None else "val_loss"
         checkpoint = pl.callbacks.ModelCheckpoint(
-            monitor=monitor, mode="min", verbose=True
+            monitor=monitor, mode="min", verbose=True, save_weights_only=True
         )
 
         custom_callbacks = self.trainer_kwargs.pop("callbacks", [])
@@ -227,9 +228,15 @@ class PyTorchLightningEstimator(Estimator):
             logger.info(
                 f"Loading best model from {checkpoint.best_model_path}"
             )
-            best_model = training_network.__class__.load_from_checkpoint(
+            # Restore the best weights into the already-built module. The
+            # checkpoint holds only tensors, so ``weights_only=True`` works.
+            best_model = training_network
+            best_checkpoint = torch.load(
                 checkpoint.best_model_path,
+                map_location="cpu",
+                weights_only=True,
             )
+            best_model.load_state_dict(best_checkpoint["state_dict"])
         else:
             best_model = training_network
 

--- a/src/gluonts/torch/model/i_transformer/lightning_module.py
+++ b/src/gluonts/torch/model/i_transformer/lightning_module.py
@@ -49,7 +49,6 @@ class ITransformerLightningModule(pl.LightningModule):
         weight_decay: float = 1e-8,
     ):
         super().__init__()
-        self.save_hyperparameters()
         self.model = ITransformerModel(**model_kwargs)
         self.num_parallel_samples = num_parallel_samples
         self.lr = lr

--- a/src/gluonts/torch/model/lag_tst/lightning_module.py
+++ b/src/gluonts/torch/model/lag_tst/lightning_module.py
@@ -48,7 +48,6 @@ class LagTSTLightningModule(pl.LightningModule):
         weight_decay: float = 1e-8,
     ):
         super().__init__()
-        self.save_hyperparameters()
         self.model = LagTSTModel(**model_kwargs)
         self.lr = lr
         self.weight_decay = weight_decay

--- a/src/gluonts/torch/model/mqf2/estimator.py
+++ b/src/gluonts/torch/model/mqf2/estimator.py
@@ -139,6 +139,14 @@ class MQF2MultiHorizonEstimator(DeepAREstimator):
             threshold_input > 0
         ), "clamping threshold for input must be positive"
 
+        # The model summary runs a forward pass that samples from the PICNN,
+        # which relies on nested ``autograd.grad`` calls that fail with recent
+        # torch versions. Disable it unless the user overrides it explicitly.
+        trainer_kwargs = {
+            "enable_model_summary": False,
+            **(trainer_kwargs or {}),
+        }
+
         distr_output = MQF2DistributionOutput(
             prediction_length=prediction_length,
             is_energy_score=is_energy_score,

--- a/src/gluonts/torch/model/mqf2/lightning_module.py
+++ b/src/gluonts/torch/model/mqf2/lightning_module.py
@@ -57,7 +57,6 @@ class MQF2MultiHorizonLightningModule(pl.LightningModule):
         patience: int = 10,
     ) -> None:
         super().__init__()
-        self.save_hyperparameters()
         self.model = MQF2MultiHorizonModel(**model_kwargs)
         self.lr = lr
         self.weight_decay = weight_decay

--- a/src/gluonts/torch/model/patch_tst/lightning_module.py
+++ b/src/gluonts/torch/model/patch_tst/lightning_module.py
@@ -48,7 +48,6 @@ class PatchTSTLightningModule(pl.LightningModule):
         weight_decay: float = 1e-8,
     ):
         super().__init__()
-        self.save_hyperparameters()
         self.model = PatchTSTModel(**model_kwargs)
         self.lr = lr
         self.weight_decay = weight_decay

--- a/src/gluonts/torch/model/simple_feedforward/lightning_module.py
+++ b/src/gluonts/torch/model/simple_feedforward/lightning_module.py
@@ -48,7 +48,6 @@ class SimpleFeedForwardLightningModule(pl.LightningModule):
         weight_decay: float = 1e-8,
     ):
         super().__init__()
-        self.save_hyperparameters()
         self.model = SimpleFeedForwardModel(**model_kwargs)
         self.lr = lr
         self.weight_decay = weight_decay

--- a/src/gluonts/torch/model/tft/lightning_module.py
+++ b/src/gluonts/torch/model/tft/lightning_module.py
@@ -51,7 +51,6 @@ class TemporalFusionTransformerLightningModule(pl.LightningModule):
         weight_decay: float = 0.0,
     ):
         super().__init__()
-        self.save_hyperparameters()
         self.model = TemporalFusionTransformerModel(**model_kwargs)
         self.lr = lr
         self.patience = patience

--- a/src/gluonts/torch/model/tide/lightning_module.py
+++ b/src/gluonts/torch/model/tide/lightning_module.py
@@ -53,7 +53,6 @@ class TiDELightningModule(pl.LightningModule):
         patience: int = 10,
     ):
         super().__init__()
-        self.save_hyperparameters()
         self.model = TiDEModel(**model_kwargs)
         self.lr = lr
         self.weight_decay = weight_decay

--- a/src/gluonts/torch/model/wavenet/lightning_module.py
+++ b/src/gluonts/torch/model/wavenet/lightning_module.py
@@ -41,7 +41,6 @@ class WaveNetLightningModule(pl.LightningModule):
         weight_decay: float = 1e-8,
     ) -> None:
         super().__init__()
-        self.save_hyperparameters()
         self.model = WaveNet(**model_kwargs)
         self.lr = lr
         self.weight_decay = weight_decay


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Bump lightning to <2.7
- Remove model hyperparameters from the lightning checkpoint for all torch models - this caused problems when loading checkpoints with `torch.load(..., weights_only=True)`
- Disable model summary for MQF2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup