### PR TITLE
Handle zero seasonal error in MASE and MSIS

### DIFF
--- a/src/gluonts/evaluation/metrics.py
+++ b/src/gluonts/evaluation/metrics.py
@@ -105,6 +105,9 @@ def mase(
 
     See [HA21]_ for more details.
     """
+    if seasonal_error == 0:
+        return np.nan
+
     return np.mean(np.abs(target - forecast)) / seasonal_error
 
 
@@ -146,6 +149,9 @@ def msis(
 
     See [SSA20]_ for more details.
     """  # noqa: E501
+
+    if seasonal_error == 0:
+        return np.nan
 
     numerator = np.mean(
         upper_quantile

--- a/test/evaluation/test_metrics.py
+++ b/test/evaluation/test_metrics.py
@@ -57,7 +57,7 @@ CONSTANT = np.array([0.4] * 5)
             ZEROES,
             [
                 (mase, 0.2 / 10e-10, {"seasonal_error": 10e-10}),
-                (mase, np.inf, {"seasonal_error": 0.0}),
+                (mase, np.nan, {"seasonal_error": 0.0}),
                 (mse, 0.06, {}),
                 (abs_error, 1.0, {}),
                 (quantile_loss, 0.2, {"q": 0.1}),
@@ -161,7 +161,7 @@ def test_target_metrics(target, metric, expected):
 @pytest.mark.parametrize(
     "target, lower_quantile, upper_quantile, seasonal_error, alpha, expected",
     [
-        (LINEAR, ZEROES, CONSTANT, 0.0, 0.05, np.inf),
+        (LINEAR, ZEROES, CONSTANT, 0.0, 0.05, np.nan),
         (LINEAR, ZEROES, CONSTANT, 1.0, 0.05, 0.4),
         (LINEAR, ZEROES, CONSTANT, 0.01, 0.05, 40.0),
         (ZEROES, ZEROES, ZEROES, 0.0, 0.05, np.nan),


### PR DESCRIPTION
*Issue #, if available:* #3097

*Description of changes:*

Return `NaN` from MASE and MSIS when their seasonal-error denominator is zero. These scaled metrics are undefined for invariant target series; representing that as `NaN` lets the default `aggregate_no_nan` strategy exclude only the inapplicable series while retaining information from valid series.

The existing parameterized metric tests now cover nonzero forecast errors with a zero seasonal error for both metrics.

## Test plan

- [x] Confirmed both updated regression cases fail before the source fix (`inf` returned instead of `NaN`)
- [x] `pytest -q test/evaluation/test_metrics.py` (22 passed)
- [x] `pytest -q test/evaluation/test_evaluator.py` (36 passed)
- [x] `ruff format --check src/gluonts/evaluation/metrics.py test/evaluation/test_metrics.py`
- [x] `ruff check src/gluonts/evaluation/metrics.py test/evaluation/test_metrics.py`
- [x] Confirmed `aggregate_no_nan` preserves valid MASE/MSIS values when another series returns `NaN`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
