### PR TITLE
Skip cpflows dependent tests

### DIFF
--- a/.github/workflows/tests-torch.yml
+++ b/.github/workflows/tests-torch.yml
@@ -25,7 +25,7 @@ jobs:
       run: uv python install ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: uv sync --no-dev --python ${{ matrix.python-version }} --extra arrow --extra torch --extra cpflows --extra shell --extra test --extra m-competitions
+      run: uv sync --no-dev --python ${{ matrix.python-version }} --extra arrow --extra torch --extra shell --extra test --extra m-competitions
 
     - name: Test with pytest
       run: |


### PR DESCRIPTION
This is wip towards removing this additional dependency altogether, hopefully. It currently holds numpy and pandas back. For now, just remove it from test workflows.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup