### PR TITLE
Serde: restrict decode to known-serializable types

### DIFF
--- a/src/gluonts/core/serde/_base.py
+++ b/src/gluonts/core/serde/_base.py
@@ -11,6 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+import dataclasses
 import textwrap
 from enum import Enum
 from functools import singledispatch, partial
@@ -295,6 +296,85 @@ decode_disallow = [
     input,
 ]
 
+# `decode` only instantiates types that `encode` is known to produce. A class
+# not covered by the checks below is rejected rather than instantiated.
+
+# Builtins that `encode` emits directly (tuples/sets, methods via `getattr`,
+# `functools.partial`).
+decode_allow_builtins = frozenset(
+    {tuple, set, frozenset, list, dict, getattr, partial}
+)
+
+# Fully-qualified names of the constructors emitted by the registered `encode`
+# implementations (see serde/np.py, serde/pd.py, mx/serde.py,
+# zebras/_period.py). Backends that add new `encode.register` handlers must add
+# their target here as well.
+decode_allow_fqnames = frozenset(
+    {
+        "numpy.dtype",
+        "numpy.array",
+        "numpy.datetime64",
+        "pandas.Timestamp",
+        "pandas.Period",
+        "pandas.tseries.frequencies.to_offset",
+        "mxnet.nd.array",
+        "mxnet.context.Context",
+        "gluonts.zebras.periods",
+    }
+)
+
+
+def _is_decode_safe(cls: Any, class_name: str) -> bool:
+    """
+    Whether ``cls`` (located from ``class_name``) is a type that
+    :func:`decode` should instantiate. Only targets that :func:`encode` is
+    known to produce are allowed.
+    """
+    if class_name in decode_allow_fqnames:
+        return True
+
+    if cls in decode_allow_builtins:
+        return True
+
+    if isinstance(cls, type):
+        # classes that explicitly opt into serde
+        if issubclass(cls, (Stateless, Stateful, PurePath, BaseModel)):
+            return True
+        # NamedTuple subclasses, encoded as instances
+        if (
+            issubclass(cls, tuple)
+            and hasattr(cls, "_fields")
+            and hasattr(cls, "_make")
+        ):
+            return True
+        # dataclasses are data containers; `encode` reconstructs them from
+        # their fields. This covers both `serde.dataclass` and plain
+        # dataclasses that expose `__init_passed_kwargs__` on instances.
+        if dataclasses.is_dataclass(cls):
+            return True
+
+    # `@validated` classes carry the pydantic model on their wrapped __init__;
+    # this marker is attached at import time (see component.validated).
+    if getattr(getattr(cls, "__init__", None), "Model", None) is not None:
+        return True
+
+    # `serde.dataclass` classes are turned into pydantic dataclasses at import
+    # time, which attach this marker (see serde._dataclass).
+    if hasattr(cls, "__pydantic_model__") or hasattr(
+        cls, "__pydantic_fields__"
+    ):
+        return True
+
+    # classes that expose their init kwargs, or are reconstructable via the
+    # pickle `__getnewargs_ex__` protocol -- both are encoding paths `encode`
+    # relies on for such types
+    if hasattr(cls, "__init_passed_kwargs__") or hasattr(
+        cls, "__getnewargs_ex__"
+    ):
+        return True
+
+    return False
+
 
 def decode(r: Any) -> Any:
     """
@@ -327,7 +407,16 @@ def decode(r: Any) -> Any:
             raise ValueError(f"{r['class']} cannot be run.")
 
         if kind == Kind.Type:
+            # `Kind.Type` returns the located object without calling it.
             return cls
+
+        # `Kind.Instance` and `Kind.Stateful` both instantiate `cls`, so it is
+        # restricted to the types `encode` can produce.
+        if not _is_decode_safe(cls, r["class"]):
+            raise ValueError(
+                f"{r['class']} is not a serde-decodable type and "
+                f"cannot be instantiated during decoding."
+            )
 
         args = decode(r.get("args", []))
         kwargs = decode(r.get("kwargs", {}))

--- a/test/core/test_serde.py
+++ b/test/core/test_serde.py
@@ -144,6 +144,27 @@ def test_np_str_dtype():
     serde.decode(serde.encode(a.dtype)) == a.dtype
 
 
+def test_serde_init_passed_kwargs():
+    # classes encoded via `__init_passed_kwargs__` (e.g. zebras periods) must
+    # round-trip through the allowlist
+    from gluonts import zebras as zb
+
+    for obj in [
+        zb.period("2021-01-01", "D"),
+        zb.periods("2021-01-01", "D", 10),
+    ]:
+        assert serde.decode(serde.encode(obj)) == obj
+
+
+def test_serde_dataclass_instance():
+    # dataclasses that set `__init_passed_kwargs__` on the instance (not the
+    # class), such as `transform.Chain`, must round-trip through the allowlist
+    from gluonts.transform import Chain, Identity
+
+    chain = Chain([Identity(), Identity()])
+    assert serde.decode(serde.encode(chain)) == chain
+
+
 @pytest.mark.parametrize(
     "obj",
     [
@@ -165,3 +186,62 @@ def test_np_str_dtype():
 def test_decode_disallow(obj):
     with pytest.raises(ValueError):
         serde.decode(obj)
+
+
+# `decode` only instantiates types that `encode` is known to produce; other
+# classes should be rejected rather than instantiated.
+@pytest.mark.parametrize(
+    "class_name",
+    [
+        "subprocess.run",
+        "subprocess.Popen",
+        "subprocess.call",
+        "os.system",
+        "os.popen",
+        "ctypes.CDLL",
+        "builtins.__import__",
+        "webbrowser.open",
+    ],
+)
+@pytest.mark.parametrize("kind", ["instance", "stateful"])
+def test_decode_rejects_arbitrary_callables(class_name, kind):
+    with pytest.raises(ValueError):
+        serde.decode(
+            {
+                "__kind__": kind,
+                "class": class_name,
+                "args": [],
+                "kwargs": {},
+            }
+        )
+
+
+def test_decode_rejects_unknown_class_in_predictor(tmp_path):
+    # End-to-end: a predictor.json referencing a class `encode` never produces
+    # is rejected when loaded through the deserialize API.
+    from gluonts.model.predictor import Predictor
+
+    canary = tmp_path / "canary"
+    (tmp_path / "gluonts-config.json").write_text(
+        serde.dump_json(
+            {
+                "type": "gluonts.model.predictor.RepresentablePredictor",
+                "version": "test",
+            }
+        )
+    )
+    (tmp_path / "predictor.json").write_text(
+        serde.dump_json(
+            {
+                "__kind__": "instance",
+                "class": "subprocess.run",
+                "args": [["/bin/sh", "-c", f"touch {canary}"]],
+                "kwargs": {},
+            }
+        )
+    )
+
+    with pytest.raises(ValueError):
+        Predictor.deserialize(tmp_path)
+
+    assert not canary.exists()


### PR DESCRIPTION
`serde.decode` previously instantiated any class it could resolve from a `class` name, guarded only by a short list of disallowed builtins. This replaces that list with an allowlist: `decode` now only instantiates types that `encode` is known to produce.

Allowed targets:
- classes that opt into serde (`@validated`, `serde.dataclass`, and subclasses of `Stateless`/`Stateful`/`PurePath`/`BaseModel`)
- NamedTuples and types that define `__getnewargs_ex__`
- a fixed set of builtins (`tuple`, `set`, `getattr`, `partial`, ...)
- the constructors emitted by the registered numpy/pandas/mxnet/zebras encoders, listed by name

`Kind.Type` is unchanged: it returns the located object without calling it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup