### PR TITLE
Fix MeanEstimator to ignore NaNs in training data

### DIFF
--- a/src/gluonts/model/trivial/mean.py
+++ b/src/gluonts/model/trivial/mean.py
@@ -165,7 +165,7 @@ class MeanEstimator(Estimator):
         )
 
         samples = np.broadcast_to(
-            array=contexts.mean(axis=0),
+            array=np.nanmean(contexts, axis=0),
             shape=(self.num_samples, self.prediction_length),
         )
 

--- a/test/model/trivial/test_mean.py
+++ b/test/model/trivial/test_mean.py
@@ -1,0 +1,51 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import numpy as np
+import pytest
+
+from gluonts.dataset.common import ListDataset
+from gluonts.model.trivial.mean import MeanEstimator
+
+
+def train_predictor(targets, prediction_length=2, num_samples=3, freq="D"):
+    dataset = ListDataset(
+        [{"target": target, "start": "2020"} for target in targets],
+        freq=freq,
+    )
+    estimator = MeanEstimator(
+        prediction_length=prediction_length,
+        num_samples=num_samples,
+    )
+    return estimator.train(dataset), dataset
+
+
+@pytest.mark.parametrize(
+    "targets, prediction_length, expected_mean",
+    [
+        ([[1, 2, 3], [1, 4, 5]], 2, [3.0, 4.0]),
+        ([[1, 2, 3]], 3, [1.0, 2.0, 3.0]),
+        # NaN in one series must not poison the mean (issue #2175)
+        ([[1, 2, np.nan], [1, 4, 5]], 2, [3.0, 5.0]),
+        ([[np.nan, np.nan, np.nan], [1, 4, 5]], 2, [4.0, 5.0]),
+    ],
+)
+def test_mean_estimator(targets, prediction_length, expected_mean):
+    predictor, dataset = train_predictor(
+        targets, prediction_length=prediction_length
+    )
+
+    forecast = next(iter(predictor.predict(dataset)))
+
+    assert forecast.samples.shape == (3, prediction_length)
+    np.testing.assert_equal(forecast.samples[0], expected_mean)


### PR DESCRIPTION
## Description

A single NaN anywhere in the training data caused `MeanEstimator` to produce all-NaN forecasts for every series, because the per-timestep mean over series is computed with `ndarray.mean`. As reported in #2175, one missing value in one series poisons all metrics for the whole backtest.

This PR switches the computation to `np.nanmean`, which is already the convention used by `MeanPredictor` and `MovingAveragePredictor` in the same module, so `MeanEstimator` now behaves consistently with its neighbors.

It also adds tests for `MeanEstimator` (previously untested), including the NaN cases: a partially-NaN series and an all-NaN series.

Fixes #2175

## Testing

`pytest test/model/trivial/` — 35 passed (4 new).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
