### PR TITLE
fix(util): reject tar link members escaping extraction target

### DIFF
--- a/src/gluonts/util.py
+++ b/src/gluonts/util.py
@@ -101,9 +101,7 @@ def will_extractall_into(tar: tarfile.TarFile, path: Path) -> None:
             try:
                 link_target.relative_to(path)
             except ValueError:
-                raise PermissionError(
-                    f"'{member.name}' links out of target."
-                )
+                raise PermissionError(f"'{member.name}' links out of target.")
 
 
 def safe_extractall(

--- a/src/gluonts/util.py
+++ b/src/gluonts/util.py
@@ -12,6 +12,7 @@
 # permissions and limitations under the License.
 
 import copy
+import sys
 import tarfile
 from functools import lru_cache
 from pathlib import Path
@@ -88,6 +89,22 @@ def will_extractall_into(tar: tarfile.TarFile, path: Path) -> None:
         except ValueError:
             raise PermissionError(f"'{member.name}' extracts out of target.")
 
+        # Reject links whose target escapes the destination.
+        if member.issym() or member.islnk():
+            if member.issym():
+                # symlink target is relative to the link's directory
+                link_target = (member_path.parent / member.linkname).resolve()
+            else:
+                # hardlink target is an archive-root-relative name
+                link_target = (path / member.linkname).resolve()
+
+            try:
+                link_target.relative_to(path)
+            except ValueError:
+                raise PermissionError(
+                    f"'{member.name}' links out of target."
+                )
+
 
 def safe_extractall(
     tar: tarfile.TarFile,
@@ -101,4 +118,12 @@ def safe_extractall(
     files to be strictly within the given ``path``.
     """
     will_extractall_into(tar, path)
-    tar.extractall(path, members, numeric_owner=numeric_owner)
+
+    # Defense in depth: the ``data`` filter (Python 3.12+) also blocks
+    # unsafe members.
+    if sys.version_info >= (3, 12):
+        tar.extractall(
+            path, members, numeric_owner=numeric_owner, filter="data"
+        )
+    else:
+        tar.extractall(path, members, numeric_owner=numeric_owner)

--- a/src/gluonts/util.py
+++ b/src/gluonts/util.py
@@ -89,19 +89,11 @@ def will_extractall_into(tar: tarfile.TarFile, path: Path) -> None:
         except ValueError:
             raise PermissionError(f"'{member.name}' extracts out of target.")
 
-        # Reject links whose target escapes the destination.
+        # GluonTS archives never legitimately contain links; a symlink or
+        # hardlink can redirect a later member's write outside the target,
+        # so reject them outright.
         if member.issym() or member.islnk():
-            if member.issym():
-                # symlink target is relative to the link's directory
-                link_target = (member_path.parent / member.linkname).resolve()
-            else:
-                # hardlink target is an archive-root-relative name
-                link_target = (path / member.linkname).resolve()
-
-            try:
-                link_target.relative_to(path)
-            except ValueError:
-                raise PermissionError(f"'{member.name}' links out of target.")
+            raise PermissionError(f"'{member.name}' is a link.")
 
 
 def safe_extractall(

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -64,34 +64,20 @@ def test_will_extractall_into(arcname: Optional[str], expect_failure: bool):
 
 
 @pytest.mark.parametrize("link_type", [tarfile.SYMTYPE, tarfile.LNKTYPE])
-def test_will_extractall_into_rejects_link_escape(link_type):
-    # A link whose target points outside the destination must be rejected.
-    with tempfile.TemporaryDirectory() as tempdir:
-        dest = Path(tempdir) / "b"
-        archive_path = Path(tempdir) / "archive.tar.gz"
-
-        with tarfile.open(archive_path, "w:gz") as tar:
-            link = tarfile.TarInfo("escape")
-            link.type = link_type
-            link.linkname = str(Path(tempdir) / "outside")  # outside dest
-            tar.addfile(link)
-
-        with tarfile.open(archive_path, "r:gz") as tar:
-            with pytest.raises(PermissionError):
-                will_extractall_into(tar, dest)
-
-
-def test_will_extractall_into_allows_internal_symlink():
-    # A symlink pointing within the destination is still accepted.
+@pytest.mark.parametrize("linkname", ["/etc/passwd", "target.txt"])
+def test_will_extractall_into_rejects_links(link_type, linkname):
+    # Links are rejected regardless of where their target points, since
+    # GluonTS archives never legitimately contain them.
     with tempfile.TemporaryDirectory() as tempdir:
         dest = Path(tempdir) / "b"
         archive_path = Path(tempdir) / "archive.tar.gz"
 
         with tarfile.open(archive_path, "w:gz") as tar:
             link = tarfile.TarInfo("link")
-            link.type = tarfile.SYMTYPE
-            link.linkname = "target.txt"  # sibling inside destination
+            link.type = link_type
+            link.linkname = linkname
             tar.addfile(link)
 
         with tarfile.open(archive_path, "r:gz") as tar:
-            will_extractall_into(tar, dest)
+            with pytest.raises(PermissionError):
+                will_extractall_into(tar, dest)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -61,3 +61,37 @@ def test_will_extractall_into(arcname: Optional[str], expect_failure: bool):
         else:
             with tarfile.open(Path(tempdir) / "archive.tar.gz", "r:gz") as tar:
                 will_extractall_into(tar, Path(tempdir) / "b")
+
+
+@pytest.mark.parametrize("link_type", [tarfile.SYMTYPE, tarfile.LNKTYPE])
+def test_will_extractall_into_rejects_link_escape(link_type):
+    # A link whose target points outside the destination must be rejected.
+    with tempfile.TemporaryDirectory() as tempdir:
+        dest = Path(tempdir) / "b"
+        archive_path = Path(tempdir) / "archive.tar.gz"
+
+        with tarfile.open(archive_path, "w:gz") as tar:
+            link = tarfile.TarInfo("escape")
+            link.type = link_type
+            link.linkname = str(Path(tempdir) / "outside")  # outside dest
+            tar.addfile(link)
+
+        with tarfile.open(archive_path, "r:gz") as tar:
+            with pytest.raises(PermissionError):
+                will_extractall_into(tar, dest)
+
+
+def test_will_extractall_into_allows_internal_symlink():
+    # A symlink pointing within the destination is still accepted.
+    with tempfile.TemporaryDirectory() as tempdir:
+        dest = Path(tempdir) / "b"
+        archive_path = Path(tempdir) / "archive.tar.gz"
+
+        with tarfile.open(archive_path, "w:gz") as tar:
+            link = tarfile.TarInfo("link")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "target.txt"  # sibling inside destination
+            tar.addfile(link)
+
+        with tarfile.open(archive_path, "r:gz") as tar:
+            will_extractall_into(tar, dest)


### PR DESCRIPTION
*Description of changes:*

safe_extractall validated only member names, so a symlink (or hardlink) member whose target pointed outside the destination passed validation. extractall then created the link and wrote a following member through it, allowing arbitrary file write (path traversal).

Inspect link members in will_extractall_into and reject any whose resolved target escapes the destination. Also pass filter="data" on Python 3.12+ as defense in depth. Adds regression tests for symlink/hardlink escape and a benign internal symlink.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup