### PR TITLE
Fix MAE_Coverage quantile lookup

### DIFF
--- a/src/gluonts/evaluation/_base.py
+++ b/src/gluonts/evaluation/_base.py
@@ -556,7 +556,7 @@ class Evaluator:
 
         totals["MAE_Coverage"] = np.mean(
             [
-                np.abs(totals[f"Coverage[{quantile}]"] - np.array([q.value]))
+                np.abs(totals[f"Coverage[{q}]"] - np.array([q.value]))
                 for q in self.quantiles
             ]
         )

--- a/test/evaluation/test_evaluator.py
+++ b/test/evaluation/test_evaluator.py
@@ -46,6 +46,33 @@ def fcst_iterator(fcst, start_dates):
         )
 
 
+def test_mae_coverage_uses_corresponding_quantile():
+    metric_per_ts = pd.DataFrame(
+        {
+            "MSE": [0.0],
+            "abs_error": [0.0],
+            "abs_target_sum": [1.0],
+            "abs_target_mean": [1.0],
+            "seasonal_error": [1.0],
+            "MASE": [0.0],
+            "MAPE": [0.0],
+            "sMAPE": [0.0],
+            "MSIS": [0.0],
+            "num_masked_target_values": [0.0],
+            "QuantileLoss[0.1]": [0.0],
+            "Coverage[0.1]": [0.1],
+            "QuantileLoss[0.9]": [0.0],
+            "Coverage[0.9]": [0.9],
+        }
+    )
+
+    metrics, _ = Evaluator(quantiles=[0.1, 0.9]).get_aggregate_metrics(
+        metric_per_ts
+    )
+
+    assert metrics["MAE_Coverage"] == pytest.approx(0.0)
+
+
 def naive_forecaster(ts, prediction_length, num_samples=100, target_dim=0):
     """
     :param ts: pandas.Series


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

Hi! I was curious about formalizing some of the evaluator metrics in Lean with
[TorchLean](https://github.com/lean-dojo/TorchLean), and noticed a small
discrepancy in the legacy `Evaluator`'s `MAE_Coverage` calculation.

The list comprehension iterates over each quantile, but the coverage lookup was
using `quantile` left over from the previous loop. For perfectly calibrated
coverages at 0.1 and 0.9, that makes the metric return 0.4 instead of 0. This
changes the lookup to use the corresponding quantile and adds a regression test
for that case.

Tests:
- `PYTHONPATH=src python -m pytest test/evaluation/test_evaluator.py -q` (37 passed)
- `ruff format --check src/gluonts/evaluation/_base.py test/evaluation/test_evaluator.py`
- `ruff check src/gluonts/evaluation/_base.py test/evaluation/test_evaluator.py`

I also have a small corresponding Lean/TorchLean formalization of the example if
that would be useful :)

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.

Suggested label: bug fix
