### PR TITLE
Fix weighted_average reduction for dim=0

### DIFF
--- a/src/gluonts/torch/util.py
+++ b/src/gluonts/torch/util.py
@@ -95,10 +95,13 @@ def weighted_average(
             weights != 0, x * weights, torch.zeros_like(x)
         )
         sum_weights = torch.clamp(
-            weights.sum(dim=dim) if dim else weights.sum(), min=1.0
+            weights.sum(dim=dim) if dim is not None else weights.sum(),
+            min=1.0,
         )
         return (
-            weighted_tensor.sum(dim=dim) if dim else weighted_tensor.sum()
+            weighted_tensor.sum(dim=dim)
+            if dim is not None
+            else weighted_tensor.sum()
         ) / sum_weights
     else:
         return x.mean(dim=dim)

--- a/test/torch/test_torch_util.py
+++ b/test/torch/test_torch_util.py
@@ -19,7 +19,17 @@ import torch
 from gluonts.torch.util import (
     lagged_sequence_values,
     unsqueeze_expand,
+    weighted_average,
 )
+
+
+def test_weighted_average_dim_zero():
+    x = torch.tensor([[1.0, 10.0], [3.0, 30.0]])
+    weights = torch.tensor([[1.0, 1.0], [3.0, 1.0]])
+
+    result = weighted_average(x, weights=weights, dim=0)
+
+    torch.testing.assert_close(result, torch.tensor([2.5, 20.0]))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

Hi! I was playing around with formalizing the behavior of `weighted_average` in Lean with [TorchLean](https://github.com/lean-dojo/TorchLean), and noticed that `dim=0` takes the all-dimensions branch because zero is falsey.

When weights are provided, this collapses the whole tensor to a scalar instead of reducing along the first axis. This changes the condition to distinguish `dim=0` from `dim=None` and adds a regression test with nonuniform weights. The existing all-dimensions behavior for `dim=None` stays the same.

Tests:
- `PYTHONPATH=src python -m pytest test/torch/test_torch_util.py -q` (8 passed)
- `ruff format --check src/gluonts/torch/util.py test/torch/test_torch_util.py`
- `ruff check src/gluonts/torch/util.py test/torch/test_torch_util.py`

I also have a corresponding TorchLean tensor formalization of the axis-zero
shape and value if that would be useful :)

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.

Suggested label: bug fix
