### PR TITLE
Allow toolz 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "pandas>=1.4,<3",
     "pydantic>=1.7,<3",
     "tqdm~=4.23",
-    "toolz~=0.10",
+    "toolz>=0.10,<=1.0.0",
     "typing-extensions~=4.0",
 ]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allow toolz 1.0.0 version as a dependency.

According to the toolz's release notes it's safe to do since the changes between 0.12.1 (the last 0.x version) and 1.0.0 are strictly about dropping Python 3.7 support, adding Python 3.13 test and some docs updates:
https://github.com/pytoolz/toolz/compare/0.12.1...1.0.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup

**Test plan:**
```
uv run pytest 
```

```
================================================= test session starts =================================================
platform darwin -- Python 3.14.5, pytest-9.1.1, pluggy-1.6.0
Fugue tests will be initialized with options:
rootdir: /Users/mhovorchuk/gluonts
configfile: pyproject.toml
testpaths: test
plugins: xdist-3.8.0, timeout-2.4.0, cov-4.1.0, rerunfailures-13.0, anyio-4.14.2, fugue-0.9.7
timeout: 60.0s
timeout method: signal
timeout func_only: False
collected 2339 items / 2 errors                                                                                       

======================================================= ERRORS ========================================================
_______________________ ERROR collecting test/nursery/sagemaker_sdk/test_entry_point_scripts.py _______________________
ImportError while importing test module '/Users/mhovorchuk/gluonts/test/nursery/sagemaker_sdk/test_entry_point_scripts.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.14/3.14.5/Frameworks/Python.framework/Versions/3.14/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/nursery/sagemaker_sdk/test_entry_point_scripts.py:22: in <module>
    from gluonts.mx import SimpleFeedForwardEstimator
src/gluonts/mx/__init__.py:21: in <module>
    import mxnet as mx
E   ModuleNotFoundError: No module named 'mxnet'
_______________________ ERROR collecting test/nursery/sagemaker_sdk/test_entry_point_scripts.py _______________________
ImportError while importing test module '/Users/mhovorchuk/gluonts/test/nursery/sagemaker_sdk/test_entry_point_scripts.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.14/3.14.5/Frameworks/Python.framework/Versions/3.14/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/nursery/sagemaker_sdk/test_entry_point_scripts.py:22: in <module>
    from gluonts.mx import SimpleFeedForwardEstimator
src/gluonts/mx/__init__.py:21: in <module>
    import mxnet as mx
E   ModuleNotFoundError: No module named 'mxnet'
=============================================== short test summary info ===============================================
ERROR test/nursery/sagemaker_sdk/test_entry_point_scripts.py
ERROR test/nursery/sagemaker_sdk/test_entry_point_scripts.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================== 2 errors in 1.55s ==================================================
```

Note that there are 2 errors in the test result. I believe it's because I'm on Mac and there is no mxnet wheel available for it.