### PR TITLE
Fix SampleForecast quantile interpolation

### DIFF
--- a/src/gluonts/model/forecast.py
+++ b/src/gluonts/model/forecast.py
@@ -23,7 +23,6 @@ from gluonts.core.component import validated
 from gluonts.pydantic import dataclass
 from gluonts import maybe
 
-
 logger = logging.getLogger(__name__)
 
 MEAN_NOT_STORED_MSG = (
@@ -491,8 +490,16 @@ class SampleForecast(Forecast):
 
     def quantile(self, q: Union[float, str]) -> np.ndarray:
         q = Quantile.parse(q).value
-        sample_idx = int(np.round((self.num_samples - 1) * q))
-        return self._sorted_samples[sample_idx, :]
+        # Match NumPy's default linear interpolation while reusing the cached
+        # sorted samples across the many quantiles used during evaluation.
+        sample_idx = (self.num_samples - 1) * q
+        lower_idx = int(np.floor(sample_idx))
+        upper_idx = int(np.ceil(sample_idx))
+        weight = sample_idx - lower_idx
+        return (
+            self._sorted_samples[lower_idx, :] * (1 - weight)
+            + self._sorted_samples[upper_idx, :] * weight
+        )
 
     def copy_dim(self, dim: int) -> "SampleForecast":
         if len(self.samples.shape) == 2:

--- a/test/ev/test_metrics_compared_to_previous_approach.py
+++ b/test/ev/test_metrics_compared_to_previous_approach.py
@@ -96,8 +96,14 @@ class SampleForecastBatch:
 
     def quantile(self, q: Union[float, str]) -> np.ndarray:
         q = Quantile.parse(q).value
-        sample_idx = int(np.round((self.num_samples - 1) * q))
-        return self._sorted_samples[:, sample_idx, :]
+        sample_idx = (self.num_samples - 1) * q
+        lower_idx = int(np.floor(sample_idx))
+        upper_idx = int(np.ceil(sample_idx))
+        weight = sample_idx - lower_idx
+        return (
+            self._sorted_samples[:, lower_idx, :] * (1 - weight)
+            + self._sorted_samples[:, upper_idx, :] * weight
+        )
 
     def __getitem__(self, name):
         if name == "mean":

--- a/test/model/test_forecast.py
+++ b/test/model/test_forecast.py
@@ -75,6 +75,35 @@ def test_forecast(name):
     forecast.plot()
 
 
+@pytest.mark.parametrize("num_samples", [4, 5])
+@pytest.mark.parametrize("multivariate", [False, True])
+def test_sample_forecast_quantiles_match_numpy(num_samples, multivariate):
+    samples = np.array(
+        [
+            [[0, 100], [10, 110]],
+            [[2, 102], [12, 112]],
+            [[8, 108], [18, 118]],
+            [[10, 110], [20, 120]],
+            [[15, 115], [25, 125]],
+        ]
+    )[:num_samples]
+    if not multivariate:
+        samples = samples[:, :, 0]
+
+    forecast = SampleForecast(samples=samples, start_date=START_DATE)
+
+    for quantile in [0.0, 0.25, 0.5, 0.9, 1.0]:
+        np.testing.assert_allclose(
+            forecast.quantile(quantile),
+            np.quantile(samples, quantile, axis=0),
+        )
+
+    np.testing.assert_allclose(
+        forecast.median,
+        np.median(samples, axis=0),
+    )
+
+
 def test_mean_only_forecast():
     forecast = QuantileForecast(
         forecast_arrays=np.ones(shape=(1, 12)),


### PR DESCRIPTION
*Issue #, if available:*

Fixes #3221.

*Description of changes:*

`SampleForecast.quantile()` previously rounded `(num_samples - 1) * q` to one sample index. For an even number of samples, the median therefore selected one middle sample instead of averaging the two middle values; other quantiles also jumped to the nearest sample.

This change linearly interpolates between the two adjacent sorted samples, matching the default NumPy quantile definition while retaining the cached sort used when evaluation requests many quantiles. Exact endpoints remain supported, and the same calculation is applied to univariate and multivariate forecasts.

The batched forecast fixture used to compare the new and legacy evaluation paths now follows the same quantile definition. Regression coverage compares `SampleForecast.quantile()` and `.median` against NumPy for 4 and 5 samples, univariate and multivariate shapes, endpoints, the median, and non-median quantiles.

Test plan:

- `python -m pytest -q test/model/test_forecast.py test/ev/test_metrics_compared_to_previous_approach.py test/evaluation/test_evaluator.py` (52 passed)
- complete non-nursery suite excluding two pre-existing `test_train_shell[MeanPredictor-*]` MSIS assertions (1459 passed, 73 skipped, 1 xfailed, 2 xpassed)
- `ruff format --check` on `src` and `test` (597 files already formatted)
- `ruff check` on the three changed files
- `git diff --check`

The two excluded shell cases are unchanged by this PR. In the current dependency environment they receive `inf` for MSIS with a zero seasonal-error denominator, while their historical assertion expects `nan`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Suggested label: bug fix