### PR TITLE
fix: process past dynamic categorical features

### DIFF
--- a/src/gluonts/dataset/common.py
+++ b/src/gluonts/dataset/common.py
@@ -387,6 +387,12 @@ class ProcessDataEntry:
                     is_static=False,
                 ),
                 ProcessTimeSeriesField(
+                    FieldName.PAST_FEAT_DYNAMIC_CAT,
+                    is_required=False,
+                    is_cat=True,
+                    is_static=False,
+                ),
+                ProcessTimeSeriesField(
                     FieldName.FEAT_DYNAMIC_REAL_LEGACY,  # backwards compatible
                     is_required=False,
                     is_cat=False,

--- a/test/torch/model/test_tft.py
+++ b/test/torch/model/test_tft.py
@@ -13,11 +13,16 @@
 
 from typing import List
 
+import numpy as np
 import torch
 import pytest
 
+from gluonts.dataset.common import ListDataset
 from gluonts.torch.distributions import QuantileOutput
-from gluonts.torch.model.tft import TemporalFusionTransformerLightningModule
+from gluonts.torch.model.tft import (
+    TemporalFusionTransformerEstimator,
+    TemporalFusionTransformerLightningModule,
+)
 
 
 @pytest.mark.parametrize(
@@ -137,3 +142,41 @@ def test_tft_modules(
 
     assert lightning_module.training_step(batch, batch_idx=0).shape == ()
     assert lightning_module.validation_step(batch, batch_idx=0).shape == ()
+
+
+def test_tft_estimator_accepts_past_dynamic_categorical_lists():
+    dataset = ListDataset(
+        [
+            {
+                "start": "2021-01-01 00:00:00",
+                "target": np.arange(8, dtype=np.float32),
+                "past_feat_dynamic_cat": [np.arange(8, dtype=np.int32) % 3],
+            }
+        ],
+        freq="1H",
+    )
+    estimator = TemporalFusionTransformerEstimator(
+        freq="1H",
+        prediction_length=2,
+        context_length=4,
+        time_features=[],
+        past_dynamic_cardinalities=[3],
+        batch_size=1,
+        num_batches_per_epoch=1,
+        trainer_kwargs={
+            "max_epochs": 1,
+            "accelerator": "cpu",
+            "logger": False,
+            "enable_checkpointing": False,
+        },
+    )
+
+    transformed = estimator.create_transformation().apply(
+        dataset, is_train=True
+    )
+    loader = estimator.create_training_data_loader(
+        transformed, estimator.create_lightning_module()
+    )
+
+    batch = next(iter(loader))
+    assert batch["past_feat_dynamic_cat"].shape == (1, 4, 1)


### PR DESCRIPTION
*Issue #3215*

*Description of changes:*

Convert optional `past_feat_dynamic_cat` inputs to two-dimensional `int32` arrays when creating a `ListDataset`, matching the existing handling for other dynamic categorical fields. This prevents the TFT instance splitter from indexing an unconverted Python list.

The regression test constructs a TFT training batch from list-based past categorical features. Focused dataset and TFT tests pass, along with Ruff, format, compile, and diff checks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.