### PR TITLE
Do not mutate the caller's dataframe in PandasDataset

### DIFF
--- a/src/gluonts/dataset/pandas.py
+++ b/src/gluonts/dataset/pandas.py
@@ -164,6 +164,11 @@ class PandasDataset:
     def _pair_to_dataentry(self, item_id, df) -> DataEntry:
         if isinstance(df, pd.Series):
             df = df.to_frame(name=self.target)
+        else:
+            # Shallow copy: the index assignment and the in-place sort below
+            # are otherwise visible side effects on the caller's dataframe.
+            # See GH-3263.
+            df = df.copy(deep=False)
 
         if self.timestamp:
             df.index = pd.DatetimeIndex(df[self.timestamp]).to_period(

--- a/test/dataset/test_pandas.py
+++ b/test/dataset/test_pandas.py
@@ -393,6 +393,56 @@ def test_pandas_dataset_cases(dataset, expected_entries):
         assert_recursively_equal(entry, expected_entry)
 
 
+def test_constructor_does_not_mutate_caller_index():
+    """
+    Regression test for GH-3263 — the constructor path.
+
+    ``from_long_dataframe`` was fixed to leave the caller's DataFrame
+    alone, but ``PandasDataset(...)`` still reaches
+    ``_pair_to_dataentry``, which rebinds ``df.index`` when ``timestamp``
+    is given and calls ``sort_index(inplace=True)``. Both are visible on
+    the caller's frame.
+    """
+    T = 3
+    df = pd.DataFrame(
+        {
+            "time": pd.to_datetime(
+                ["2021-01-03", "2021-01-01", "2021-01-02"]
+            ),
+            "target": np.array([3.0, 1.0, 2.0]),
+        }
+    )
+    original_index = df.index.copy()
+    original_columns = list(df.columns)
+    original_values = df.values.copy()
+
+    list(pandas.PandasDataset(df, timestamp="time", freq="1D"))
+
+    pd.testing.assert_index_equal(df.index, original_index)
+    assert list(df.columns) == original_columns
+    np.testing.assert_array_equal(df.values, original_values)
+
+
+def test_constructor_does_not_reorder_caller_rows():
+    """
+    Regression test for GH-3263 — the ``sort_index(inplace=True)`` half.
+
+    With a caller-supplied unsorted ``PeriodIndex`` no index assignment
+    happens, but the in-place sort still reorders the caller's rows.
+    """
+    index = pd.PeriodIndex(
+        ["2021-01-03", "2021-01-01", "2021-01-02"], freq="1D"
+    )
+    df = pd.DataFrame({"target": np.array([3.0, 1.0, 2.0])}, index=index)
+    original_index = df.index.copy()
+    original_values = df.values.copy()
+
+    list(pandas.PandasDataset(df, freq="1D"))
+
+    pd.testing.assert_index_equal(df.index, original_index)
+    np.testing.assert_array_equal(df.values, original_values)
+
+
 def test_from_long_dataframe_does_not_mutate_caller_index():
     """
     Regression test for GH-3263.


### PR DESCRIPTION
`_pair_to_dataentry` operates on the frame the caller passed in:

```python
def _pair_to_dataentry(self, item_id, df) -> DataEntry:
    if isinstance(df, pd.Series):
        df = df.to_frame(name=self.target)

    if self.timestamp:
        df.index = pd.DatetimeIndex(df[self.timestamp]).to_period(freq=self.freq)
    ...
    if not self.assume_sorted:
        df.sort_index(inplace=True)
```

Both the index assignment and the in-place sort are visible to the caller afterwards:

```python
df = pd.DataFrame({
    "ts": pd.to_datetime(["2021-01-03", "2021-01-01", "2021-01-02"]),
    "y":  [3.0, 1.0, 2.0],
})
list(PandasDataset(df, target="y", timestamp="ts", freq="D"))
```

```
df.index   before [0, 1, 2]                after [2021-01-01, 2021-01-02, 2021-01-03]
df["y"]    before [3.0, 1.0, 2.0]          after [1.0, 2.0, 3.0]
```

With a caller-supplied unsorted `PeriodIndex` no index assignment happens, but `sort_index(inplace=True)` still reorders their rows.

This is the same defect #3298 fixed in `from_long_dataframe`, which took a shallow copy for exactly this reason and cited GH-3263. The constructor path was left unchanged and GH-3263 is still open, so this applies the same fix there.

Scope:

- The dataset entries are byte-identical before and after — `start=2021-01-01`, `target=[1.0, 2.0, 3.0]` either way. Only the side effect goes away.
- `pd.Series` inputs already went through `to_frame`, which copies, so only the DataFrame branch changes.
- The copy is shallow, matching #3298, so no column data is duplicated.

Added two tests next to the existing `from_long_dataframe` ones, one for each side effect: the index rebinding (via `timestamp=`) and the in-place sort (via an unsorted `PeriodIndex`). Both fail on `dev` and pass here; `test/dataset/test_pandas.py` goes 31 -> 33 passing.
