### PR TITLE
fix: handle zero frequency in get_seasonality

### DIFF
--- a/src/gluonts/time_feature/seasonality.py
+++ b/src/gluonts/time_feature/seasonality.py
@@ -46,6 +46,13 @@ def get_seasonality(freq: str, seasonalities=DEFAULT_SEASONALITIES) -> int:
     """
     offset = pd.tseries.frequencies.to_offset(freq)
 
+    if offset.n == 0:
+        logger.warning(
+            f"Frequency {freq!r} has a multiple of 0. "
+            "Falling back to seasonality 1."
+        )
+        return 1
+
     base_seasonality = seasonalities.get(norm_freq_str(offset.name), 1)
 
     seasonality, remainder = divmod(base_seasonality, offset.n)

--- a/test/time_feature/test_seasonality.py
+++ b/test/time_feature/test_seasonality.py
@@ -18,6 +18,7 @@ from gluonts.time_feature import get_seasonality
 from .common import H, M, Q, Y
 
 TEST_CASES = [
+    ("0h", 1),
     ("30min", 48),
     ("5B", 1),
     ("1B", 5),


### PR DESCRIPTION
*Issue #, if available:*

Fixes #3343

*Description of changes:*

`pandas.to_offset()` accepts zero-multiple frequency strings such as `0h`, but `get_seasonality()` passed the resulting `offset.n == 0` to `divmod`, raising `ZeroDivisionError`.

This change handles that case using the function's existing fallback contract: emit a warning and return seasonality `1`. It also adds `0h` to the parameterized regression cases.

Validation:

- Existing target baseline: `26 passed`
- New test against the old implementation: `1 failed, 26 passed` with the expected `ZeroDivisionError`
- Fixed target file: `27 passed`
- Adjacent `test/time_feature` suite: `106 passed`
- Ruff 0.2.2 on both changed files: passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
