### PR TITLE
fix(torch): handle loc=None in PiecewiseLinearOutput.distribution

### DIFF
--- a/src/gluonts/torch/distributions/piecewise_linear.py
+++ b/src/gluonts/torch/distributions/piecewise_linear.py
@@ -239,7 +239,12 @@ class PiecewiseLinearOutput(DistributionOutput):
         else:
             distr = self.distr_cls(*distr_args)
             return TransformedPiecewiseLinear(
-                distr, [AffineTransform(loc=loc, scale=scale)]
+                distr,
+                [
+                    AffineTransform(
+                        loc=0.0 if loc is None else loc, scale=scale
+                    )
+                ],
             )
 
     @property

--- a/test/torch/distribution/test_torch_piecewise_linear.py
+++ b/test/torch/distribution/test_torch_piecewise_linear.py
@@ -218,3 +218,51 @@ def test_robustness():
     # check that 0 <= crps
     crps_x = distr.crps(x)
     assert torch.min(crps_x).item() >= 0.0
+
+
+@pytest.mark.parametrize(
+    "loc_kwargs",
+    [{}, {"loc": None}],
+    ids=["loc-omitted", "loc-none"],
+)
+def test_scale_without_loc(loc_kwargs: dict):
+    """
+    An omitted or ``None`` ``loc`` must be treated as zero when ``scale``
+    is given, matching ``AffineTransformed`` and every other
+    ``DistributionOutput``.
+
+    Regression test for https://github.com/awslabs/gluonts/issues/3114:
+    ``PiecewiseLinearOutput.distribution`` forwarded ``loc=None`` verbatim
+    into ``AffineTransform``, so the first use of the returned
+    distribution raised ``TypeError: unsupported operand type(s) for +:
+    'NoneType' and 'Tensor'``.
+    """
+    batch_shape = (3,)
+    num_pieces = 4
+
+    gamma = torch.zeros(batch_shape)
+    slopes = torch.ones(*batch_shape, num_pieces)
+    knot_spacings = torch.full((*batch_shape, num_pieces), 1.0 / num_pieces)
+    distr_args = (gamma, slopes, knot_spacings)
+    scale = torch.full(batch_shape, 2.0)
+
+    distr_out = PiecewiseLinearOutput(num_pieces=num_pieces)
+
+    implicit = distr_out.distribution(distr_args, scale=scale, **loc_kwargs)
+    explicit = distr_out.distribution(
+        distr_args, loc=torch.zeros(batch_shape), scale=scale
+    )
+
+    # sampling must work at all, and agree with an explicit zero ``loc``
+    torch.manual_seed(0)
+    implicit_sample = implicit.sample()
+    torch.manual_seed(0)
+    explicit_sample = explicit.sample()
+
+    assert implicit_sample.shape == batch_shape
+    assert torch.isfinite(implicit_sample).all()
+    assert torch.allclose(implicit_sample, explicit_sample)
+
+    # the training path (CRPS) must work too
+    target = torch.ones(batch_shape)
+    assert torch.allclose(implicit.crps(target), explicit.crps(target))


### PR DESCRIPTION
*Issue #, if available:*

Fixes #3114

*Description of changes:*

### Problem

`PiecewiseLinearOutput` is unusable as a `distr_output` on the PyTorch side. The reproducer in #3114 — `DeepAREstimator(..., distr_output=PiecewiseLinearOutput(num_pieces=4)).train(...)` — dies with:

```
File "torch/distributions/transforms.py", line 830, in _call
    return self.loc + self.scale * x
TypeError: unsupported operand type(s) for +: 'NoneType' and 'Tensor'
```

The same model works under the MXNet implementation, so this is a regression in the torch port rather than an unsupported configuration. Two independent reporters on the issue.

### Why it matters

This is not an edge case reachable only through a hand-rolled call. `DeepARModel.forward` calls `self.output_distribution(repeated_params, trailing_n=1, scale=repeated_scale)` — `scale` supplied, `loc` omitted — which is precisely the broken combination. Every torch model that scales its target and selects `PiecewiseLinearOutput` hits it, so the distribution is effectively dead on this backend. It also breaks **training**, not just sampling (see below), so there is no partial workaround.

### Root cause

`PiecewiseLinearOutput.distribution` overrides the base `DistributionOutput` seam and constructs a raw `AffineTransform` directly:

```python
return TransformedPiecewiseLinear(
    distr, [AffineTransform(loc=loc, scale=scale)]
)
```

Every other output routes through `AffineTransformed`, whose constructor normalizes the optional arguments:

```python
self.scale = 1.0 if scale is None else scale
self.loc = 0.0 if loc is None else loc
```

Bypassing that normalization means `loc=None` is forwarded verbatim into `AffineTransform`. Note the failure is *deferred*: the distribution constructs successfully and stores `loc=None`, then raises on first use. Two surfaces are affected by the one cause:

| surface | path | error |
|---|---|---|
| sampling / prediction | `AffineTransform._call` → `self.loc + self.scale * x` | `unsupported operand type(s) for +: 'NoneType' and 'Tensor'` |
| CRPS / `log_prob` (training) | `AffineTransform._inverse` → `(y - self.loc) / self.scale` | `unsupported operand type(s) for -: 'Tensor' and 'NoneType'` |

Control: `NormalOutput` given the identical `loc=None, scale=<tensor>` call works fine, confirming the defect is local to this override and not the framework contract.

`mypy` already flagged this statically on `dev`, which is corroborating evidence rather than a new finding:

```
src/gluonts/torch/distributions/piecewise_linear.py:242: error: Argument "loc" to
"AffineTransform" has incompatible type "Tensor | None"; expected "Tensor | float"
```

### What changed

Normalize an omitted or `None` `loc` to zero on the branch that builds the transform, matching `AffineTransformed` exactly:

```python
return TransformedPiecewiseLinear(
    distr,
    [AffineTransform(loc=0.0 if loc is None else loc, scale=scale)],
)
```

Using the Python float `0.0` rather than a zeros tensor is deliberate on three counts: it is literally what `AffineTransformed` uses, so the two seams cannot drift; it carries no device, so nothing needs device plumbing; and torch's weak scalar promotion leaves the operand dtype untouched, where a `torch.zeros(...)` default would risk an unintended upcast.

This also clears the `mypy` error quoted above (`mypy src`: 128 → 127 errors, no new ones).

### Tests

Added `test_scale_without_loc` to `test/torch/distribution/test_torch_piecewise_linear.py`, parametrized over both spellings of the bug (`loc` omitted, and `loc=None` passed explicitly).

The assertion is an **equivalence contract** — an omitted `loc` must behave identically to an explicit zero `loc` — rather than hardcoded expected values, so it stays meaningful if sampling internals change. It covers both affected surfaces: `sample()` and `crps()`. Deterministic (`torch.manual_seed`), CPU-only, no datasets, no network, ~2s.

Verified RED before / GREEN after on the same commit base:

```
# before the src change
2 failed, 8 passed   ← TypeError: unsupported operand type(s) for +: 'NoneType' and 'Tensor'
# after
10 passed
```

No `loss()` assertion: `PiecewiseLinear` implements no `log_prob`, so the base `DistributionOutput.loss` raises `NotImplementedError` regardless of this fix. `crps` is the path `DeepAR` actually trains on.

### Manual verification

- Focused test: 2 passed.
- Full `test/torch/distribution/`: **471 passed**.
- Full `test/torch/`: **5 failed, 570 passed, 2 skipped** — and the pristine `dev` baseline on the same machine gives **5 failed, 568 passed, 2 skipped** with a *byte-identical* failure set (`test_estimators.py::test_estimator_constant_dataset[…8/9]`, `test_estimator_with_features[<lambda>4]`). Those are pre-existing and local-environment-specific (Lightning selects the `mps` accelerator here); the delta is exactly the 2 new tests.
- `ruff format --check`, `ruff check`, `.devtools/license check`: clean on both files (pinned `ruff==0.2.2`).
- `mypy src` (pinned `1.8.0`): 127 errors vs 128 on baseline, none in `torch/distributions/piecewise_linear.py` beyond the pre-existing ones.
- Independent review pass over the transform contract: broadcasting (batch shapes `(1,)`, `(3,)`, `(10,5)`, `(2,3,4)`; scalar / `(1,)` / `(3,)` scale), dtype preservation (`float32` and `float64` both round-trip unchanged), device-agnosticism, and autograd (gradients still reach `scale`, `gamma`, `slopes`, and an explicitly-passed `loc`).

Two notes for reviewers, neither introduced here:

- `dev` is currently red on `style-type-checks` and `test (3.14)` independently of this PR, from unrelated numpy-typing drift (`gluonts/itertools.py`, `zebras/`, `ev/stats.py`).
- `ISQFOutput.distribution` in `src/gluonts/torch/distributions/isqf.py:813` carries the **identical** latent defect and the same `mypy` diagnostic. Left alone here to keep this PR to one behaviour change — happy to follow up if you'd like it fixed the same way.

*Screenshots:* N/A — library-internal change, no user-visible UI.

### Scope

Intentionally minimal: one behaviour change, on one branch of one method.

`PiecewiseLinearOutput.distribution` has a **second**, independent defect — when `scale is None` but `loc` *is* provided, the `loc` is silently discarded and an untransformed distribution is returned. That is a different failure mode (wrong values, no exception), it is not what #3114 reports, and fixing it would change behaviour for callers who pass `loc` alone. Deliberately left as-is; a test in this PR pins that branch's current behaviour so the omission is explicit rather than accidental. Happy to address it separately if you'd like.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Please tag this pr with at least one of these labels to make our release process faster:** BREAKING, new feature, bug fix, other change, dev setup
