### PR TITLE
fix(nursery): `@validted` -> `@validated` — importing pts.model.n_beats raises NameError

### DIFF
--- a/src/gluonts/nursery/robust-mts-attack/pts/model/n_beats/n_beats_ensemble.py
+++ b/src/gluonts/nursery/robust-mts-attack/pts/model/n_beats/n_beats_ensemble.py
@@ -187,7 +187,7 @@ class NBEATSEnsembleEstimator(PyTorchEstimator):
         Arguments passed down to the individual estimators.
     """
 
-    @validted()
+    @validated()
     def __init__(
         self,
         freq: str,


### PR DESCRIPTION
### What

`src/gluonts/nursery/robust-mts-attack/pts/model/n_beats/n_beats_ensemble.py:190`
decorates `NBEATSEnsembleEstimator.__init__` with `@validted()` — one letter
short of the `validated` imported at line 21:

```python
21: from gluonts.core.component import validated
...
190:    @validted()
191:    def __init__(
```

`pyflakes` on current `dev`:

```
.../pts/model/n_beats/n_beats_ensemble.py:190:6: undefined name 'validted'
```

The sibling estimator in the same package spells it correctly
(`pts/model/n_beats/n_beats_estimator.py:47: @validated()`), and `validted` does
not exist anywhere in the tree.

### Why it matters

A decorator expression is evaluated when the class body executes, i.e. at import
time — and `pts/model/n_beats/__init__.py:14` re-exports this class:

```python
from .n_beats_ensemble import NBEATSEnsembleEstimator
```

So `import pts.model.n_beats` — which is also how `NBEATSEstimator` is reached —
raises `NameError: name 'validted' is not defined` before anything can run.

```
UNPATCHED (@validted)    -> NameError: name 'validted' is not defined
PATCHED (@validated)     -> module imported OK
```

### Fix

`validted` → `validated`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
