### PR TITLE
Fix enable_checkpointing=False raising MisconfigurationException (#3203)

### DIFF
--- a/src/gluonts/torch/model/estimator.py
+++ b/src/gluonts/torch/model/estimator.py
@@ -193,16 +193,22 @@ class PyTorchLightningEstimator(Estimator):
                 from_predictor.network.state_dict()
             )
 
-        monitor = "train_loss" if validation_data is None else "val_loss"
-        checkpoint = pl.callbacks.ModelCheckpoint(
-            monitor=monitor, mode="min", verbose=True, save_weights_only=True
-        )
-
         custom_callbacks = self.trainer_kwargs.pop("callbacks", [])
+        checkpoint = None
+        if self.trainer_kwargs.get("enable_checkpointing", True):
+            monitor = "train_loss" if validation_data is None else "val_loss"
+            checkpoint = pl.callbacks.ModelCheckpoint(
+                monitor=monitor,
+                mode="min",
+                verbose=True,
+                save_weights_only=True,
+            )
+            custom_callbacks = [checkpoint] + custom_callbacks
+
         trainer = pl.Trainer(
             **{
                 "accelerator": "auto",
-                "callbacks": [checkpoint] + custom_callbacks,
+                "callbacks": custom_callbacks,
                 **self.trainer_kwargs,
             }
         )
@@ -215,7 +221,7 @@ class PyTorchLightningEstimator(Estimator):
                 ckpt_path=ckpt_path,
             )
         except Exception as e:
-            if checkpoint.best_model_path == "":
+            if checkpoint is None or checkpoint.best_model_path == "":
                 logger.error("Training failed with no checkpoint available")
                 raise
             else:
@@ -224,7 +230,7 @@ class PyTorchLightningEstimator(Estimator):
                     f"with the following exception:\n {e}"
                 )
 
-        if checkpoint.best_model_path != "":
+        if checkpoint is not None and checkpoint.best_model_path != "":
             logger.info(
                 f"Loading best model from {checkpoint.best_model_path}"
             )

--- a/test/torch/model/test_estimators.py
+++ b/test/torch/model/test_estimators.py
@@ -20,7 +20,7 @@ import pytest
 import pandas as pd
 import numpy as np
 from lightning import seed_everything
-from lightning.pytorch.callbacks import Callback
+from lightning.pytorch.callbacks import Callback, ModelCheckpoint
 
 from gluonts.dataset.repository import get_dataset
 from gluonts.model.predictor import Predictor
@@ -431,4 +431,21 @@ def test_estimator_recovers_if_exception_encountered_during_training():
     predictor = estimator.train(dataset.train)
     forecast = list(predictor.predict(dataset.train))
     assert callback.raised
+    assert isinstance(forecast[0].mean, np.ndarray)
+
+
+def test_estimator_respects_enable_checkpointing_false():
+    dataset = get_dataset("constant")
+    estimator = DeepAREstimator(
+        freq=dataset.metadata.freq,
+        prediction_length=5,
+        batch_size=4,
+        num_batches_per_epoch=3,
+        trainer_kwargs=dict(max_epochs=1, enable_checkpointing=False),
+    )
+    output = estimator.train_model(dataset.train)
+    assert not any(
+        isinstance(cb, ModelCheckpoint) for cb in output.trainer.callbacks
+    )
+    forecast = list(islice(output.predictor.predict(dataset.train), 1))
     assert isinstance(forecast[0].mean, np.ndarray)


### PR DESCRIPTION
*Issue #, if available:* #3203

*Description of changes:*

`PyTorchLightningEstimator.train_model` always injected a `ModelCheckpoint`
callback. Passing `trainer_kwargs={"enable_checkpointing": False}` therefore
hit Lightning's MisconfigurationException:

    Trainer was configured with 3 but found
    4 in callbacks list.

The default `ModelCheckpoint` is now added only when checkpointing is left
enabled (the previous default). With checkpointing off, training keeps the
last-epoch weights. Custom callbacks are unchanged.

A regression test fails without this change (`MisconfigurationException`)
and passes with it. The reporter's TFT snippet in #3203 trains to a
`PyTorchPredictor` after the change.

*What I chose:* honor `enable_checkpointing=False` only.
*Alternative:* also skip the default callback when the caller already passed
a `ModelCheckpoint` (would let them set `dirpath`, e.g. `/tmp/checkpoints`,
as mentioned in the issue edit). MXNet's trainer already skips defaults when
the caller supplied the same callback type.
*Reasoning:* the labeled failure is the exception at Trainer construction.
Lightning already honors `Trainer(default_root_dir=...)` for a
`ModelCheckpoint` created with `dirpath=None`. Smallest reversible change;
happy to switch if you want the skip-if-user-supplied behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Please tag this pr with at least one of these labels to make our release process faster:** bug fix

Fixes #3203
