### PR TITLE
Fix BinnedUniformsOutput construction and DeepAR logits unpacking (#3107)

### DIFF
--- a/src/gluonts/torch/distributions/binned_uniforms.py
+++ b/src/gluonts/torch/distributions/binned_uniforms.py
@@ -449,7 +449,7 @@ class BinnedUniformsOutput(DistributionOutput):
         bins_upper_bound: float,
         num_bins: int,
     ) -> None:
-        super().__init__(self)
+        super().__init__()
 
         assert (
             isinstance(num_bins, int) and num_bins > 1
@@ -469,10 +469,12 @@ class BinnedUniformsOutput(DistributionOutput):
         )
 
     @classmethod
-    def domain_map(cls, logits: torch.Tensor) -> torch.Tensor:  # type: ignore
+    def domain_map(  # type: ignore
+        cls, logits: torch.Tensor
+    ) -> Tuple[torch.Tensor]:
         logits = torch.abs(logits)
 
-        return logits
+        return (logits,)
 
     def distribution(
         self,
@@ -483,7 +485,7 @@ class BinnedUniformsOutput(DistributionOutput):
         return self.distr_cls(
             self.bins_lower_bound,
             self.bins_upper_bound,
-            distr_args,
+            *distr_args,
             self.num_bins,
         )
 

--- a/test/torch/distribution/test_binned_uniforms.py
+++ b/test/torch/distribution/test_binned_uniforms.py
@@ -1,0 +1,57 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import torch
+
+from gluonts.torch.distributions import BinnedUniforms, BinnedUniformsOutput
+
+
+def test_binned_uniforms_output_constructs():
+    distr_output = BinnedUniformsOutput(
+        bins_lower_bound=0.0, bins_upper_bound=1.0, num_bins=2
+    )
+    assert distr_output.num_bins == 2
+    assert distr_output.beta == 0.0
+
+
+def test_binned_uniforms_output_distribution_from_args_proj():
+    """DeepAR (and other estimators) pass `distr_args` as a tuple of tensors
+    from `get_args_proj`. `BinnedUniforms` needs the unpacked logits tensor.
+    """
+    num_bins = 2
+    batch_size, time_length, in_features = 4, 8, 5
+    prediction_length = 3
+
+    distr_output = BinnedUniformsOutput(
+        bins_lower_bound=0.0, bins_upper_bound=1.0, num_bins=num_bins
+    )
+    args_proj = distr_output.get_args_proj(in_features=in_features)
+    net_out = torch.randn(batch_size, time_length, in_features)
+    distr_args = args_proj(net_out)
+
+    assert isinstance(distr_args, tuple)
+    assert len(distr_args) == 1
+    (logits,) = distr_args
+    assert logits.shape == (batch_size, time_length, num_bins)
+
+    # DeepAR slices the last `prediction_length` steps into a list/tuple.
+    sliced_params = [p[:, -prediction_length:] for p in distr_args]
+    distr = distr_output.distribution(sliced_params)
+
+    assert isinstance(distr, BinnedUniforms)
+    assert distr.batch_shape == (batch_size, prediction_length)
+
+    target = torch.rand(batch_size, prediction_length)
+    loss = distr_output.loss(target=target, distr_args=tuple(sliced_params))
+    assert loss.shape == (batch_size, prediction_length)
+    assert torch.isfinite(loss).all()


### PR DESCRIPTION
*Issue #, if available:* #3107

*Description of changes:*

`BinnedUniformsOutput` could not be used with `DeepAREstimator`. The reporter's traceback is `AttributeError: 'list' object has no attribute 'shape'` inside `BinnedUniforms.__init__` when it reads `logits.shape`. Provenance: the traceback in #3107 (GluonTS 0.14.3). No maintainer comments on the issue.

On current `dev`, construction fails first: `super().__init__(self)` passes the instance as `DistributionOutput.beta`, and pydantic rejects it. After that, two wiring bugs remain and match the report:

- `distribution()` forwarded the `distr_args` tuple as `logits` instead of unpacking it. DeepAR always passes a list/tuple of tensors from `get_args_proj`.
- `domain_map` returned a raw tensor. Single-parameter outputs in this repo return a 1-tuple so that DeepAR's `[p[:, -n:] for p in params]` iterates parameters, not the batch axis.

This change matches existing siblings:

- `super().__init__()` like `PiecewiseLinearOutput` / `SplicedBinnedParetoOutput`
- `domain_map` returns `(logits,)` like `PoissonOutput`
- `*distr_args` like `SplicedBinnedParetoOutput`

What I chose, and the alternative: still ignore `loc`/`scale` in `BinnedUniformsOutput.distribution`. Alternative: wrap `AffineTransformed` as the parent class does (DeepAR always passes a scaler `scale`). Reasoning: bins are specified in observation space; changing scaling is a behaviour change beyond the crash. Happy to switch if you want scaled-space bins.

*Tests:* `test/torch/distribution/test_binned_uniforms.py` covers construction, the args-proj tuple, DeepAR-style slicing, and `loss`. Confirmed red without the source change and green with it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Please tag this pr with at least one of these labels to make our release process faster:** bug fix

Fixes #3107
